### PR TITLE
Update deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,7 @@ jobs:
           name: Deploy API
           command: |
             . venv/bin/activate
-            . ./scripts/helpers.sh
-            deploy_api development
+            sh ./scripts/deploy-api.sh development
 
   # run api tests
   api:
@@ -236,8 +235,7 @@ jobs:
           name: Deploy frontend
           command: |
             . venv/bin/activate
-            . ./scripts/helpers.sh
-            deploy_frontend development
+            sh ./scripts/deploy-frontend.sh development
 
   # run client tests
   frontend:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+# Helpers for common tasks
+deploy-api:
+	./scripts/deploy-api.sh ${ENVIRONMENT}
+
+deploy-frontend:
+	./scripts/deploy-frontend.sh ${ENVIRONMENT}
+
+publish-api:
+	./scripts/build-api.sh
+	./scripts/publish-api.sh
+
+publish-frontend:
+	./scripts/build-frontend.sh
+	./scripts/publish-frontend.sh

--- a/api/index.js
+++ b/api/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const setupRoutes = require('./routes');
+const morgan = require('morgan');
 
 const app = express();
 
@@ -11,6 +12,8 @@ const port = process.env.PORT || 5000;
 app.use(cors({ credentials: true, origin: true }));
 // enable parsing of JSON in POST request bodies
 app.use(express.json());
+// add logging
+app.use(morgan('common'));
 
 // Routes:
 setupRoutes(app);

--- a/api/package.json
+++ b/api/package.json
@@ -19,6 +19,7 @@
     "express": "^4.16.4",
     "express-validator": "^5.3.1",
     "ipfs-mini": "^1.1.5",
+    "morgan": "^1.9.1",
     "pg": "^7.8.0",
     "pg-hstore": "^2.3.2",
     "sequelize": "^4.42.0",

--- a/api/routes.js
+++ b/api/routes.js
@@ -1,11 +1,46 @@
+const { sequelize } = require('./models');
 const { checkSchema } = require('express-validator/check');
 const { proposalSchema } = require('./utils/proposals');
 const proposal = require('./controllers/proposal');
 const slate = require('./controllers/slate');
 
+const eth = require('./utils/eth');
+
 module.exports = app => {
   app.get('/', (req, res) => {
     res.send('This is the Panvala API');
+  });
+
+  /**
+   * Readiness probe
+   * Return 200 once the application is ready
+   */
+  app.get('/ready', (req, res) => {
+    const dbCheck = sequelize
+      .authenticate()
+      .then(() => {
+        console.log('Connection has been established successfully.');
+      })
+      .catch(err => {
+        const msg = 'Unable to connect to the database';
+        console.error(msg, err);
+        throw new Error(msg);
+      });
+
+    const ethCheck = eth.checkConnection().catch(err => {
+      const msg = 'Unable to reach the Ethereum network';
+      console.error(msg, err);
+      throw new Error(msg);
+    });
+
+    Promise.all([dbCheck, ethCheck])
+      .then(() => {
+        res.send('ok');
+      })
+      .catch(err => {
+        console.error(err);
+        res.status(500).send('Not ready');
+      });
   });
 
   // PROPOSALS

--- a/api/utils/eth.js
+++ b/api/utils/eth.js
@@ -1,0 +1,17 @@
+const ethers = require('ethers');
+const config = require('./config');
+const { rpcEndpoint } = config;
+
+/**
+ * Check connection
+ */
+function checkConnection() {
+  // console.log('Connecting to', rpcEndpoint);
+  const provider = new ethers.providers.JsonRpcProvider(rpcEndpoint);
+
+  return provider.getBlockNumber();
+}
+
+module.exports = {
+  checkConnection,
+};

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -645,6 +645,13 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+basic-auth@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
@@ -3205,6 +3212,17 @@ moment-timezone@^0.5.14:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
+morgan@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
+  integrity sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==
+  dependencies:
+    basic-auth "~2.0.0"
+    debug "2.6.9"
+    depd "~1.1.2"
+    on-finished "~2.3.0"
+    on-headers "~1.0.1"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -3436,6 +3454,11 @@ on-finished@~2.3.0:
   integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
   dependencies:
     ee-first "1.1.1"
+
+on-headers@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
+  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"

--- a/charts/panvala-api/templates/deployment.yaml
+++ b/charts/panvala-api/templates/deployment.yaml
@@ -30,19 +30,49 @@ spec:
           env:
             - name: NODE_ENV
               value: {{ .Values.node_env }}
+            # Database values (from config map)
             - name: PRODUCTION_HOST
-              value: {{ .Values.databaseHost }}
+              valueFrom:
+                configMapKeyRef:
+                  name: db-config
+                  key: host
             - name: PRODUCTION_PORT
-              value: {{ .Values.databasePort | quote }}
+              valueFrom:
+                configMapKeyRef:
+                  name: db-config
+                  key: port
             - name: PRODUCTION_DATABASE
-              value: {{ .Values.databaseName }}
+              valueFrom:
+                configMapKeyRef:
+                  name: db-config
+                  key: name
             - name: PRODUCTION_USERNAME
-              value: {{ .Values.databaseUser }}
+              valueFrom:
+                configMapKeyRef:
+                  name: db-config
+                  key: user
+            # Read database password from secret
             - name: PRODUCTION_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+                  name: db-secret
                   key: databasePassword
+            - name: GATEKEEPER_ADDRESS
+            # Contract info (from config map)
+              valueFrom:
+                configMapKeyRef:
+                  name: contracts-config
+                  key: gatekeeper
+            - name: TOKEN_CAPACITOR_ADDRESS
+              valueFrom:
+                configMapKeyRef:
+                  name: contracts-config
+                  key: tokenCapacitor
+            # IPFS
+            - name: IPFS_HOST
+              value: {{ .Values.ipfsHost }}
+            - name: IPFS_PORT
+              value: {{ .Values.ipfsPort | quote }}
           livenessProbe:
             httpGet:
               path: /

--- a/charts/panvala-api/templates/deployment.yaml
+++ b/charts/panvala-api/templates/deployment.yaml
@@ -73,6 +73,9 @@ spec:
               value: {{ .Values.ipfsHost }}
             - name: IPFS_PORT
               value: {{ .Values.ipfsPort | quote }}
+            # Web3
+            - name: RPC_ENDPOINT
+              value: {{ .Values.web3Host }}
           livenessProbe:
             httpGet:
               path: /

--- a/charts/panvala-api/values.yaml
+++ b/charts/panvala-api/values.yaml
@@ -7,11 +7,8 @@ environment: production
 node_env: production
 containerPort: 5000
 
-databaseHost: panvala-db
-databasePort: "5432"
-databaseName: panvala_api
-databaseUser: root
-databasePassword: password
+ipfsHost: ipfs.infura.io
+ipfsPort: 5001
 
 ##
 
@@ -26,7 +23,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 service:
-  type: LoadBalancer
+  type: ClusterIP
   port: 80
 
 ingress:

--- a/charts/panvala-api/values.yaml
+++ b/charts/panvala-api/values.yaml
@@ -10,6 +10,8 @@ containerPort: 5000
 ipfsHost: ipfs.infura.io
 ipfsPort: 5001
 
+web3Host: https://rinkeby.infura.io:8545
+
 ##
 
 replicaCount: 1

--- a/charts/panvala-base/.helmignore
+++ b/charts/panvala-base/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/panvala-base/Chart.yaml
+++ b/charts/panvala-base/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Initial setup for a Panvala environment
+name: panvala-base
+version: 0.1.0

--- a/charts/panvala-base/templates/_helpers.tpl
+++ b/charts/panvala-base/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "panvala-base.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "panvala-base.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "panvala-base.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/panvala-base/templates/contracts-configmap.yaml
+++ b/charts/panvala-base/templates/contracts-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contracts-config
+data:
+  gatekeeper: {{ .Values.gatekeeper }}
+  tokenCapacitor: {{ .Values.tokenCapacitor }}

--- a/charts/panvala-base/templates/db-config.yml
+++ b/charts/panvala-base/templates/db-config.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-config
+data:
+  name: {{ .Values.databaseName }}
+  user: {{ .Values.databaseUser }}
+  host: {{ .Values.databaseHost }}
+  port: {{ .Values.databasePort | quote }}

--- a/charts/panvala-base/templates/db-secret.yml
+++ b/charts/panvala-base/templates/db-secret.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  name: db-secret
 type: Opaque
 data:
   databasePassword: {{ default "" .Values.databasePassword | b64enc | quote }}

--- a/charts/panvala-base/templates/db-service.yml
+++ b/charts/panvala-base/templates/db-service.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: panvala-db
+spec:
+  type: ExternalName
+  externalName: {{ .Values.databaseExternalHost }}

--- a/charts/panvala-base/values.yaml
+++ b/charts/panvala-base/values.yaml
@@ -1,0 +1,55 @@
+# Default values for panvala-base.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+
+# The host of the database to be exposed to the cluster as a service
+databaseExternalHost: localhost
+
+# database config
+# The database host that the other services will point to
+databaseHost: panvala-db
+databasePort: 5432
+databaseName: panvala_api
+databaseUser: panvala
+databasePassword: password
+
+
+# contract addresses
+gatekeeper: "0xcc20cbD0F5534f85F0042eC99Fd1C4f4608a31B9"
+tokenCapacitor: "0x6BAD8c9caDFC59f0f5df904765ebA360A91a59b9"
+
+
+nameOverride: ""
+fullnameOverride: ""
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  paths: []
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/panvala-frontend/templates/deployment.yaml
+++ b/charts/panvala-frontend/templates/deployment.yaml
@@ -30,6 +30,17 @@ spec:
           env:
             - name: API_HOST
               value: {{ .Values.apiHost }}
+            # Contract info
+            - name: GATEKEEPER_ADDRESS
+              valueFrom:
+                configMapKeyRef:
+                  name: contracts-config
+                  key: gatekeeper
+            - name: TOKEN_CAPACITOR_ADDRESS
+              valueFrom:
+                configMapKeyRef:
+                  name: contracts-config
+                  key: tokenCapacitor
           livenessProbe:
             httpGet:
               path: /

--- a/charts/panvala-frontend/values.yaml
+++ b/charts/panvala-frontend/values.yaml
@@ -5,7 +5,7 @@
 # custom variables
 # the container port
 containerPort: 3000
-# the API host
+# the API host - the name of the service with the API
 apiHost: panvala-api
 
 ###

--- a/charts/panvala-frontend/values.yaml
+++ b/charts/panvala-frontend/values.yaml
@@ -6,7 +6,7 @@
 # the container port
 containerPort: 3000
 # the API host - the name of the service with the API
-apiHost: panvala-api
+apiHost: http://panvala-api
 
 ###
 

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -3,6 +3,8 @@ FROM mhart/alpine-node
 # application will be installed here
 WORKDIR /srv
 
+# install curl
+RUN apk add --update curl && rm -rf /var/cache/apk/*
 
 # install dependencies
 COPY package.json .

--- a/scripts/deploy-api.sh
+++ b/scripts/deploy-api.sh
@@ -25,6 +25,7 @@ deploy() {
         --set image.tag=${TAG} \
         --set image.repository=${REPO} \
         --set service.type=LoadBalancer \
+        --set web3Host=${RPC_ENDPOINT} \
         --set nameOverride="${APP}" \
         --set fullnameOverride="${APP}" \
         "${APP}-${ENVIRONMENT}" \

--- a/scripts/deploy-api.sh
+++ b/scripts/deploy-api.sh
@@ -18,13 +18,13 @@ deploy() {
     APP="panvala-api"
 
     echo "$TAG $REPO $APP"
-    echo "$(aws ecr get-login)"
 
     helm upgrade --install \
         --namespace ${ENVIRONMENT} \
         --set environment=${ENVIRONMENT} \
         --set image.tag=${TAG} \
         --set image.repository=${REPO} \
+        --set service.type=LoadBalancer \
         --set nameOverride="${APP}" \
         --set fullnameOverride="${APP}" \
         "${APP}-${ENVIRONMENT}" \

--- a/scripts/deploy-api.sh
+++ b/scripts/deploy-api.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# deploy API
+# deploy-api.sh ENVIRONMENT
+# Environment is development, staging or production
+# Creates service panvala-api-${ENVIRONMENT}
+set -u
+set -e
+
+. scripts/helpers.sh
+
+
+# Deploy
+deploy() {
+    ENVIRONMENT=$1
+    # TAG=$(get_image_tag panvala/api)
+    REPO="$(get_image_registry)/panvala/api"
+    APP="panvala-api"
+
+    echo "$TAG $REPO $APP"
+    echo "$(aws ecr get-login)"
+
+    helm upgrade --install \
+        --namespace ${ENVIRONMENT} \
+        --set environment=${ENVIRONMENT} \
+        --set image.tag=${TAG} \
+        --set image.repository=${REPO} \
+        --set nameOverride="${APP}" \
+        --set fullnameOverride="${APP}" \
+        "${APP}-${ENVIRONMENT}" \
+        ./charts/${APP}
+}
+
+deploy $1

--- a/scripts/deploy-frontend.sh
+++ b/scripts/deploy-frontend.sh
@@ -23,6 +23,7 @@ deploy() {
         --set image.tag=${TAG} \
         --set image.repository=${REPO} \
         --set service.type=LoadBalancer \
+        --set apiHost=${API_HOST} \
         --set nameOverride="${APP}" \
         --set fullnameOverride="${APP}" \
         "${APP}-${ENVIRONMENT}" \

--- a/scripts/deploy-frontend.sh
+++ b/scripts/deploy-frontend.sh
@@ -17,11 +17,12 @@ deploy() {
     REPO="$(get_image_registry)/panvala/frontend"
     APP="panvala-frontend"
 
-    echo helm upgrade --install \
+    helm upgrade --install \
         --namespace ${ENVIRONMENT} \
         --set environment=${ENVIRONMENT} \
         --set image.tag=${TAG} \
         --set image.repository=${REPO} \
+        --set service.type=LoadBalancer \
         --set nameOverride="${APP}" \
         --set fullnameOverride="${APP}" \
         "${APP}-${ENVIRONMENT}" \

--- a/scripts/deploy-frontend.sh
+++ b/scripts/deploy-frontend.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# deploy frontend
+# deploy-frontend.sh ENVIRONMENT
+# Environment is staging or production
+# Creates service panvala-api-${ENVIRONMENT}
+set -u
+set -e
+
+. scripts/helpers.sh
+
+
+# Deploy
+deploy() {
+    ENVIRONMENT=$1
+    # TAG=$(get_image_tag panvala/api)
+    REPO="$(get_image_registry)/panvala/frontend"
+    APP="panvala-frontend"
+
+    echo helm upgrade --install \
+        --namespace ${ENVIRONMENT} \
+        --set environment=${ENVIRONMENT} \
+        --set image.tag=${TAG} \
+        --set image.repository=${REPO} \
+        --set nameOverride="${APP}" \
+        --set fullnameOverride="${APP}" \
+        "${APP}-${ENVIRONMENT}" \
+        ./charts/${APP}
+}
+
+deploy $1

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -25,44 +25,13 @@ get_image_name() {
     echo "$FULL_IMAGE_NAME"
 }
 
-# deploy_api ENVIRONMENT
-# Environment is staging or production
-# Creates service panvala-api-${ENVIRONMENT}
-deploy_api() {
-    ENVIRONMENT=$1
-    TAG=$(get_image_tag panvala/api)
-    REPO="$(get_image_registry)/panvala/api"
-    APP="panvala-api"
+# update_docker_token() {
+#     export TOKEN=$(aws ecr --region=$REGION get-authorization-token --output text --query authorizationData[].authorizationToken | base64 -d | cut -d: -f2)
+# }
 
-    helm upgrade --install \
-        --set environment=${ENVIRONMENT} \
-        --set image.tag=${TAG} \
-        --set image.repository=${REPO} \
-        --set databasePassword=${DATABASE_PASSWORD} \
-        --set databaseUser=${DATABASE_USER} \
-        --namespace ${ENVIRONMENT} \
-        ${APP}-${ENVIRONMENT} \
-        ./charts/${APP}
-}
-
-# deploy_frontend ENVIRONMENT
-# Environment is staging or production
-# Creates service panvala-api-${ENVIRONMENT}
-deploy_frontend() {
-    ENVIRONMENT=$1
-    REPO="$(get_image_registry)/panvala/frontend"
-    TAG=$(get_image_tag panvala/frontend)
-    APP="panvala-frontend"
-
-    helm upgrade --install \
-        --set environment=${ENVIRONMENT} \
-        --set apiHost=${API_HOST} \
-        --set image.tag=${TAG} \
-        --set image.repository=${REPO} \
-        --set service.type=LoadBalancer \
-        --namespace ${ENVIRONMENT} \
-        ${APP}-${ENVIRONMENT} \
-        ./charts/${APP}
+create_docker_pull_secret() {
+    NAMESPACE=$1
+    kubectl create secret generic regcred --from-file=.dockerconfigjson=$HOME/.docker/config.json --type=kubernetes.io/dockerconfigjson -n ${NAMESPACE}
 }
 
 install_helm() {

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# initialize a namespace for our applications
+# init-env.sh ENVIRONMENT
+set -u
+set -e
+
+# Delete the base release
+delete() {
+    ENVIRONMENT=$1
+    release="panvala-base-${ENVIRONMENT}"
+
+    helm delete ${release}
+}
+
+# Install the base release
+configure() {
+    ENVIRONMENT=$1
+
+    helm upgrade --install \
+        --namespace ${ENVIRONMENT} \
+        --set databaseExternalHost=${DATABASE_HOST} \
+        --set databaseUser=${DATABASE_USER} \
+        --set databasePassword=${DATABASE_PASSWORD} \
+        --set nameOverride="panvala-base" \
+        panvala-base-${ENVIRONMENT} \
+        ./charts/panvala-base
+}
+
+configure $1


### PR DESCRIPTION
This work changes the way we're passing configuration to the applications. It adds a new Helm chart `panvala-base`, that sets up configuration that the other applications can then read from. This configuration includes a reference to the database, the database configuration, and the addresses of the contracts. Instead of defining these values in the application deployments, they now read from the configuration that has already been deployed. In addition, it contains some improvements to make it easier to debug failures and misconfigurations.

* Add `panvala-base` Helm chart
* Update `panvala-api` and `panvala-frontend` charts to use resources deployed by `panvala-base`
* Add new scripts for deploying api and frontend, and update CI deploy to use them
* Add readiness probe to API at `/ready` - check database and web3 connections
* Add HTTP logging to API
* Add Makefile