### PR TITLE
Feat (ballots): client signature, api routing, and sig recovery

### DIFF
--- a/api/controllers/ballot.js
+++ b/api/controllers/ballot.js
@@ -1,9 +1,16 @@
 const { validationResult } = require('express-validator/check');
+const { utils } = require('ethers');
+const { voting } = require('../../packages/panvala-utils');
 const { SubmittedBallot, VoteChoice } = require('../models');
 const { validateBallot } = require('../utils/validation');
 
 
 module.exports = {
+  getAll(req, res) {
+    SubmittedBallot.findAll().then(ballots => {
+      res.send(ballots);
+    });
+  },
   /**
    * Create a new ballot
    */
@@ -65,12 +72,21 @@ module.exports = {
     }
 
     // Transform into the structure to be inserted into the database
-    const { ballot, signature } = req.body;
-
-    // TODO: check that the signature matches the body
-    // console.log(ballot, signature);
+    const { ballot, signature, commitHash } = req.body;
 
     const { epochNumber, salt, voterAddress, choices } = ballot;
+
+    // Regenerate commit message
+    const message = voting.generateCommitMessage(commitHash, choices['0'], salt);
+    // Recover address from signed message
+    const recoveredAddress = utils.verifyMessage(message, signature);
+    // Validate the signature
+    if (recoveredAddress !== voterAddress) {
+      return res.status(400).json({
+        msg: 'Invalid signature. Recovered signature did not match signer of the commit message.',
+        errors: errors.array(),
+      });
+    }
 
     const contests = Object.keys(choices);
     // Need to use capital `VoteChoices` for creation

--- a/api/controllers/ballot.js
+++ b/api/controllers/ballot.js
@@ -68,6 +68,7 @@ module.exports = {
 
     // Transform into the structure to be inserted into the database
     const { ballot, signature, commitHash } = req.body;
+    // TODO: send over the data in a smaller format (JSON.stringify)
 
     const { epochNumber, salt, voterAddress, choices } = ballot;
 
@@ -79,7 +80,11 @@ module.exports = {
     if (recoveredAddress !== voterAddress) {
       return res.status(400).json({
         msg: 'Invalid signature. Recovered signature did not match signer of the commit message.',
-        errors: errors.array(),
+        errors: [
+          new Error(
+            'Invalid signature. Recovered signature did not match signer of the commit message.'
+          ),
+        ],
       });
     }
 

--- a/api/controllers/ballot.js
+++ b/api/controllers/ballot.js
@@ -6,11 +6,6 @@ const { validateBallot } = require('../utils/validation');
 
 
 module.exports = {
-  getAll(req, res) {
-    SubmittedBallot.findAll().then(ballots => {
-      res.send(ballots);
-    });
-  },
   /**
    * Create a new ballot
    */

--- a/api/controllers/ballot.js
+++ b/api/controllers/ballot.js
@@ -4,7 +4,6 @@ const { voting } = require('../../packages/panvala-utils');
 const { SubmittedBallot, VoteChoice } = require('../models');
 const { validateBallot } = require('../utils/validation');
 
-
 module.exports = {
   /**
    * Create a new ballot
@@ -56,7 +55,7 @@ module.exports = {
     // Validate input
     const valid = validateBallot(req.body);
     if (!valid) {
-      const msg = 'Invalid request data';
+      const msg = 'Invalid ballot request data';
       const errors = validateBallot.errors;
 
       // console.error(errors);

--- a/api/migrations/20190327191519-unique-submitted-ballot-constraint.js
+++ b/api/migrations/20190327191519-unique-submitted-ballot-constraint.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addConstraint('SubmittedBallots', ['epochNumber', 'voterAddress'], {
+      type: 'unique',
+      name: 'singleVotePerEpoch',
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeConstraint('SubmittedBallots', 'singleVotePerEpoch');
+  },
+};

--- a/api/routes.js
+++ b/api/routes.js
@@ -59,7 +59,6 @@ module.exports = app => {
   app.post('/api/slates', checkSchema(slateSchema), slate.create);
 
   // BALLOTS
-  app.get('/api/ballots', ballot.getAll);
   app.post(
     '/api/ballots',
     ballot.process,

--- a/api/routes.js
+++ b/api/routes.js
@@ -12,7 +12,6 @@ const proposal = require('./controllers/proposal');
 const slate = require('./controllers/slate');
 const ballot = require('./controllers/ballot');
 
-
 // Routes
 module.exports = app => {
   app.get('/', (req, res) => {
@@ -60,6 +59,7 @@ module.exports = app => {
   app.post('/api/slates', checkSchema(slateSchema), slate.create);
 
   // BALLOTS
+  app.get('/api/ballots', ballot.getAll);
   app.post(
     '/api/ballots',
     ballot.process,

--- a/api/schemas/ballot.json
+++ b/api/schemas/ballot.json
@@ -65,7 +65,11 @@
       "$comment": "`0x` + 130 hex characters",
       "type": "string",
       "pattern": "^0x[a-fA-F0-9]{130}$"
+    },
+    "commitHash": {
+      "type": "string",
+      "pattern": "^0x[a-fA-F0-9]+$"
     }
   },
-  "required": ["ballot", "signature"]
+  "required": ["ballot", "signature", "commitHash"]
 }

--- a/api/schemas/ballot.json
+++ b/api/schemas/ballot.json
@@ -62,10 +62,9 @@
       "required": ["epochNumber", "choices", "voterAddress", "salt"]
     },
     "signature": {
-      "$comment": "`0x` + 64 hex characters",
+      "$comment": "`0x` + 130 hex characters",
       "type": "string",
-      "length": 66,
-      "pattern": "^0x[a-fA-F0-9]+$"
+      "pattern": "^0x[a-fA-F0-9]{130}$"
     }
   },
   "required": ["ballot", "signature"]

--- a/api/schemas/ballot.json
+++ b/api/schemas/ballot.json
@@ -1,70 +1,72 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://panvala.com/schemas/ballot.json",
-    "title": "Ballot",
-    "description": "A ballot POSTed to ballots endpoint",
-    "type": "object",
-    "definitions": {
-        "choice": {
-            "type": "string"
-        }
-    },
-    "properties": {
-        "ballot": {
-            "type": "object",
-            "properties": {
-                "epochNumber": {
-                    "type": "string",
-                    "pattern": "^[0-9]+$",
-                    "bigNumber": true
-                },
-                "choices": {
-                    "type": "object",
-                    "$comment": "Choices must parse as BigNumber",
-                    "minProperties": 1,
-                    "propertyNames": {
-                        "$comment": "Keys for choices are numerical",
-                        "pattern": "^[0-9]+$",
-                        "bigNumber": true
-                    },
-                    "patternProperties": {
-                        "": {
-                            "type": "object",
-                            "properties": {
-                                "firstChoice": {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "pattern": "^[0-9]+$",
-                                    "bigNumber": true
-                                },
-                                "secondChoice": {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "pattern": "^[0-9]+$",
-                                    "bigNumber": true
-                                }
-                            },
-                            "required": ["firstChoice", "secondChoice"]
-                        }
-                    }
-                },
-                "voterAddress": {
-                    "$comment": "Length is `0x` + 40 hex characters",
-                    "type": "string",
-                    "pattern": "^0x[a-fA-F0-9]{40}$"
-                },
-                "salt": {
-                    "type": "string",
-                    "pattern": "^[0-9]+$",
-                    "bigNumber": true
-                }
-            },
-            "required": ["epochNumber", "choices", "voterAddress", "salt"]
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://panvala.com/schemas/ballot.json",
+  "title": "Ballot",
+  "description": "A ballot POSTed to ballots endpoint",
+  "type": "object",
+  "definitions": {
+    "choice": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "ballot": {
+      "type": "object",
+      "properties": {
+        "epochNumber": {
+          "type": "string",
+          "pattern": "^[0-9]+$",
+          "bigNumber": true
         },
-        "signature": {
-            "type": "string",
-            "minLength": 1
+        "choices": {
+          "type": "object",
+          "$comment": "Choices must parse as BigNumber",
+          "minProperties": 1,
+          "propertyNames": {
+            "$comment": "Keys for choices are numerical",
+            "pattern": "^[0-9]+$",
+            "bigNumber": true
+          },
+          "patternProperties": {
+            "": {
+              "type": "object",
+              "properties": {
+                "firstChoice": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^[0-9]+$",
+                  "bigNumber": true
+                },
+                "secondChoice": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^[0-9]+$",
+                  "bigNumber": true
+                }
+              },
+              "required": ["firstChoice", "secondChoice"]
+            }
+          }
+        },
+        "voterAddress": {
+          "$comment": "Length is `0x` + 40 hex characters",
+          "type": "string",
+          "pattern": "^0x[a-fA-F0-9]{40}$"
+        },
+        "salt": {
+          "type": "string",
+          "pattern": "^[0-9]+$",
+          "bigNumber": true
         }
+      },
+      "required": ["epochNumber", "choices", "voterAddress", "salt"]
     },
-    "required": ["ballot", "signature"]
+    "signature": {
+      "$comment": "`0x` + 64 hex characters",
+      "type": "string",
+      "length": 66,
+      "pattern": "^0x[a-fA-F0-9]+$"
+    }
+  },
+  "required": ["ballot", "signature"]
 }

--- a/api/test/app.test.js
+++ b/api/test/app.test.js
@@ -332,6 +332,7 @@ describe('POST /api/ballots', () => {
         secondChoice: '2',
       },
     };
+    // NOTE: this might be problematic for testing specific fields
     const commitHash = voting.generateCommitHash(choices, salt);
     const commitMessage = voting.generateCommitMessage(commitHash, choices['0'], salt);
     const signature = await wallet.signMessage(commitMessage);
@@ -384,7 +385,7 @@ describe('POST /api/ballots', () => {
   });
 
   describe('missing required fields', () => {
-    const requiredFields = ['ballot', 'signature'];
+    const requiredFields = ['ballot', 'signature', 'commitHash'];
 
     test.each(requiredFields)('it should return a 400 if `%s` is null', async field => {
       data[field] = null;

--- a/api/test/app.test.js
+++ b/api/test/app.test.js
@@ -519,8 +519,15 @@ describe('POST /api/ballots', () => {
   });
 
   describe('field validation', () => {
-    test.todo('it should return a 400 if the signature does not match the voterAddress');
-    test.todo('it should return a 400 if the signature does not match the voterAddress');
+    test('it should return a 400 if the signature does not match the voterAddress', async () => {
+      data.ballot.voterAddress = '0xD09cc3Bc67E4294c4A446d8e4a2934a921410eD7';
+
+      const result = await request(app)
+        .post(route)
+        .send(data);
+
+      expect(result.status).toBe(400);
+    });
 
     test('it should return a 400 if the salt is not numeric', async () => {
       data.ballot.salt = 'not a number';

--- a/api/test/app.test.js
+++ b/api/test/app.test.js
@@ -371,6 +371,18 @@ describe('POST /api/ballots', () => {
     });
   });
 
+  test('it should return a 400 if the provided epochNumber && voterAddress already exist', async () => {
+    await request(app)
+      .post('/api/ballots')
+      .send(data);
+
+    const result = await request(app)
+      .post('/api/ballots')
+      .send(data);
+
+    expect(result.status).toEqual(400);
+  });
+
   test('it should return a 400 if no ballot data was provided', async () => {
     const result = await request(app).post('/api/ballots');
 

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -44,13 +44,15 @@ export default class Layout extends React.Component<IProps, IAppContext> {
       finalityDate: 0,
     },
     onNotify: () => this.handleNotify,
-    onRefreshProposals: () => this.handleRefreshProposals,
+    onRefreshProposals: () => this.handleRefreshProposals(),
+    onRefreshSlates: () => this.handleRefreshSlates(),
   };
 
   constructor(props: IProps) {
     super(props);
     this.handleNotify = this.handleNotify.bind(this);
     this.handleRefreshProposals = this.handleRefreshProposals.bind(this);
+    this.handleRefreshSlates = this.handleRefreshSlates.bind(this);
   }
 
   // runs once, onload
@@ -132,6 +134,21 @@ export default class Layout extends React.Component<IProps, IAppContext> {
   async handleRefreshProposals() {
     const proposals: IProposal[] = await this.handleGetAllProposals();
     return this.setState({ proposals });
+  }
+
+  async handleGetAllSlates() {
+    const slates: ISlate[] | AxiosResponse = await getAllSlates();
+    console.log('slates:', slates);
+    if (Array.isArray(slates)) {
+      return slates;
+    }
+
+    return [];
+  }
+
+  async handleRefreshSlates() {
+    const slates: ISlate[] = await this.handleGetAllSlates();
+    return this.setState({ slates });
   }
 
   render() {

--- a/client/components/Modal.tsx
+++ b/client/components/Modal.tsx
@@ -2,6 +2,20 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { COLORS } from '../styles';
 
+export const ModalTitle = styled.div`
+  font-size: 1.5em;
+  color: ${COLORS.grey2};
+  margin: 1em 0;
+`;
+
+export const ModalDescription = styled.div`
+  font-size: 1em;
+  color: ${COLORS.grey3};
+  line-height: 1.5em;
+  margin-bottom: 1em;
+  text-align: center;
+`;
+
 const ModalBody = styled.div`
   position: fixed;
   top: 50px;

--- a/client/interfaces/contexts.ts
+++ b/client/interfaces/contexts.ts
@@ -124,6 +124,7 @@ export interface IAppContext {
   currentBallot: IBallotDates;
   onNotify?: any;
   onRefreshProposals?: any;
+  onRefreshSlates?: any;
 }
 
 export interface IEthereumContext {

--- a/client/pages/ballots/vote.tsx
+++ b/client/pages/ballots/vote.tsx
@@ -199,8 +199,8 @@ const Vote: React.FunctionComponent<IProps> = ({ router }) => {
   return (
     <div>
       <Modal handleClick={() => setOpenModal(false)} isOpen={isOpen}>
-        <Image src="/static/check.svg" alt="ballot submitted" />
-        <ModalTitle>{'Ballot submitted.'}</ModalTitle>
+        <Image src="/static/check.svg" alt="vote submitted" />
+        <ModalTitle>{'Vote submitted.'}</ModalTitle>
         <ModalDescription className="flex flex-wrap">
           Your vote has been recorded. It won't be revealed publicly until the vote concludes.
         </ModalDescription>

--- a/client/pages/ballots/vote.tsx
+++ b/client/pages/ballots/vote.tsx
@@ -173,6 +173,8 @@ const Vote: React.FunctionComponent<IProps> = ({ router }) => {
               gasLimit: estimate.add('70000').toHexString(), // for safety, +70k gas (+20k doesn't cut it)
               gasPrice: utils.parseUnits('9.0', 'gwei'),
             });
+
+            toast.success('Successfully submitted a ballot')
           }
         } catch (error) {
           let errMsg = error.message;

--- a/client/pages/proposals/create.tsx
+++ b/client/pages/proposals/create.tsx
@@ -9,13 +9,13 @@ import { postProposal } from '../../utils/api';
 import { IProposal, IAppContext } from '../../interfaces';
 import CenteredTitle from '../../components/CenteredTitle';
 import { AxiosResponse } from 'axios';
+import { SingletonRouter, withRouter } from 'next/router';
 
 type IProps = {
-  account: string;
-  provider: any;
+  router: SingletonRouter;
 };
 
-const CreateProposal: React.FunctionComponent<IProps> = () => {
+const CreateProposal: React.FunctionComponent<IProps> = ({ router }) => {
   const { onNotify, onRefreshProposals }: IAppContext = React.useContext(AppContext);
 
   const [isOpen, setOpenModal] = React.useState(false);
@@ -28,8 +28,6 @@ const CreateProposal: React.FunctionComponent<IProps> = () => {
       if (response.status === 200) {
         setOpenModal(true);
         await onRefreshProposals();
-        // TODO: redirect: /proposals
-        // or: move this logic to proposals/index and remove from componentDidMount in Layout
       }
     } catch (error) {
       onNotify(error.message, 'error');
@@ -45,7 +43,13 @@ const CreateProposal: React.FunctionComponent<IProps> = () => {
           You have successfully created a Panvala Grant Proposal. Now groups that are creating
           slates can attach your grant to their slate.
         </ModalDescription>
-        <Button type="default" onClick={() => setOpenModal(false)}>
+        <Button
+          type="default"
+          onClick={() => {
+            setOpenModal(false);
+            router.push('/proposals');
+          }}
+        >
           {'Done'}
         </Button>
       </Modal>
@@ -58,4 +62,4 @@ const CreateProposal: React.FunctionComponent<IProps> = () => {
   );
 };
 
-export default CreateProposal;
+export default withRouter(CreateProposal);

--- a/client/pages/proposals/create.tsx
+++ b/client/pages/proposals/create.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import styled from 'styled-components';
-import { COLORS } from '../../styles';
 import { AppContext } from '../../components/Layout';
 import Button from '../../components/Button';
 import { FormWrapper } from '../../components/Form';
 import Image from '../../components/Image';
-import Modal from '../../components/Modal';
+import Modal, { ModalTitle, ModalDescription } from '../../components/Modal';
 import ProposalForm from '../../components/ProposalForm';
 import { postProposal } from '../../utils/api';
 import { IProposal, IAppContext } from '../../interfaces';
@@ -16,20 +14,6 @@ type IProps = {
   account: string;
   provider: any;
 };
-
-const ModalTitle = styled.div`
-  font-size: 1.5em;
-  color: ${COLORS.grey2};
-  margin: 1em 0;
-`;
-
-const ModalDescription = styled.div`
-  font-size: 1em;
-  color: ${COLORS.grey3};
-  line-height: 1.5em;
-  margin-bottom: 1em;
-  text-align: center;
-`;
 
 const CreateProposal: React.FunctionComponent<IProps> = () => {
   const { onNotify, onRefreshProposals }: IAppContext = React.useContext(AppContext);

--- a/client/utils/api.ts
+++ b/client/utils/api.ts
@@ -1,5 +1,5 @@
 import getConfig from 'next/config';
-import { IProposal, ISlate, ISaveSlate } from '../interfaces';
+import { IProposal, ISlate, ISaveSlate, ISubmitBallot } from '../interfaces';
 import axios, { AxiosResponse } from 'axios';
 import { proposalsArray } from './data';
 
@@ -101,7 +101,6 @@ export async function getAllSlates(): Promise<ISlate[] | AxiosResponse> {
   }
 }
 
-
 /**
  * Save slate info using the API
  * @param data
@@ -111,6 +110,35 @@ export async function postSlate(data: ISaveSlate): Promise<AxiosResponse> {
     const response = await axios({
       method: 'post',
       url: `${apiHost}/api/slates`,
+      data,
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...corsHeaders,
+      },
+    });
+    return response;
+  } catch (error) {
+    throw new Error(error);
+  }
+}
+
+/**
+ * Save ballot info using the API
+ * @param ballot
+ * @param commitHash
+ * @param signature
+ */
+export async function postBallot(ballot: ISubmitBallot, commitHash: string, signature: string) {
+  const data = {
+    ballot,
+    commitHash,
+    signature,
+  };
+  try {
+    const response = await axios({
+      method: 'post',
+      url: `${apiHost}/api/ballots`,
       data,
       headers: {
         Accept: 'application/json',

--- a/client/utils/api.ts
+++ b/client/utils/api.ts
@@ -2,6 +2,7 @@ import getConfig from 'next/config';
 import { IProposal, ISlate, ISaveSlate, ISubmitBallot } from '../interfaces';
 import axios, { AxiosResponse } from 'axios';
 import { proposalsArray } from './data';
+import { handleApiError } from './errors';
 
 // Defaults are a workaround for https://github.com/zeit/next.js/issues/4024
 const { publicRuntimeConfig = {} } = getConfig() || {};
@@ -106,21 +107,18 @@ export async function getAllSlates(): Promise<ISlate[] | AxiosResponse> {
  * @param data
  */
 export async function postSlate(data: ISaveSlate): Promise<AxiosResponse> {
-  try {
-    const response = await axios({
-      method: 'post',
-      url: `${apiHost}/api/slates`,
-      data,
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        ...corsHeaders,
-      },
-    });
-    return response;
-  } catch (error) {
-    throw new Error(error);
-  }
+  return axios({
+    method: 'post',
+    url: `${apiHost}/api/slates`,
+    data,
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      ...corsHeaders,
+    },
+  }).catch(error => {
+    throw handleApiError(error);
+  });
 }
 
 /**
@@ -135,19 +133,16 @@ export async function postBallot(ballot: ISubmitBallot, commitHash: string, sign
     commitHash,
     signature,
   };
-  try {
-    const response = await axios({
-      method: 'post',
-      url: `${apiHost}/api/ballots`,
-      data,
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        ...corsHeaders,
-      },
-    });
-    return response;
-  } catch (error) {
-    throw new Error(error);
-  }
+  return axios({
+    method: 'post',
+    url: `${apiHost}/api/ballots`,
+    data,
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      ...corsHeaders,
+    },
+  }).catch(function(error) {
+    throw handleApiError(error);
+  });
 }

--- a/client/utils/errors.ts
+++ b/client/utils/errors.ts
@@ -1,0 +1,44 @@
+import { AxiosError } from 'axios';
+
+interface ICustomApiError {
+  msg?: string;
+  errors?: any[];
+}
+
+export function handleApiError(error: AxiosError) {
+  let toastMessage;
+
+  // axios errors have a `response` field that contains the error details
+  // -> use it to unpack and display more informative, custom errors
+  // https://github.com/axios/axios/issues/960#issuecomment-309287911
+  let data: string | ICustomApiError = error.response && error.response.data;
+
+  if (
+    typeof data === 'string' &&
+    data === 'Improper ballot format: SequelizeUniqueConstraintError: Validation error'
+  ) {
+    // singleVotePerEpoch
+    toastMessage = 'Failed to save ballot - only one vote allowed per epoch.';
+  } else if (typeof data !== 'string' && data.msg && data.msg === 'Invalid ballot request data') {
+    // invalid ballot data types
+    toastMessage = 'Failed to process ballot - invalid ballot request.';
+  } else {
+    toastMessage = 'Unknown error';
+  }
+
+  return {
+    // The request was made and the server responded with a status code
+    // that falls out of the range of 2xx
+    // error.response: { data, status, headers }
+    response: error.response,
+    // The request was made but no response was received
+    // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+    // http.ClientRequest in node.js
+    request: error.request,
+    config: error.config,
+    // Something happened in setting up the request that triggered an Error
+    message: error.message,
+    // custom message for toasts
+    toastMessage,
+  };
+}

--- a/client/utils/errors.ts
+++ b/client/utils/errors.ts
@@ -12,6 +12,7 @@ export function handleApiError(error: AxiosError) {
   // -> use it to unpack and display more informative, custom errors
   // https://github.com/axios/axios/issues/960#issuecomment-309287911
   let data: string | ICustomApiError = error.response && error.response.data;
+  console.log('error.response.data:', data);
 
   if (
     typeof data === 'string' &&

--- a/client/utils/voting.ts
+++ b/client/utils/voting.ts
@@ -1,8 +1,5 @@
-import  { panvala_utils } from "./index";
+import { panvala_utils } from './index';
 
-const { generateCommitHash, randomSalt } = panvala_utils.voting;
+const { generateCommitHash, randomSalt, generateCommitMessage } = panvala_utils.voting;
 
-export {
-    generateCommitHash,
-    randomSalt,
-};
+export { generateCommitHash, randomSalt, generateCommitMessage };

--- a/packages/panvala-utils/dist/index.js
+++ b/packages/panvala-utils/dist/index.js
@@ -34,7 +34,18 @@ function randomSalt() {
     const salt = bigNumberify(randomBytes(32));
     return salt;
 }
+/**
+ * generateCommitMessage
+ *
+ * @param {string} commitHash keccak256(category + firstChoice + secondChoice ... + salt)
+ * @param {*} ballotChoices { firstChoice, secondChoice }
+ * @param {string} salt Random 256-bit number
+ */
+function generateCommitMessage(commitHash, ballotChoices, salt) {
+    return `Commit hash: ${commitHash}. First choice: ${ballotChoices.firstChoice}. Second choice: ${ballotChoices.secondChoice}. Salt: ${salt}`;
+}
 module.exports = {
     generateCommitHash,
     randomSalt,
+    generateCommitMessage,
 };

--- a/packages/panvala-utils/voting/index.ts
+++ b/packages/panvala-utils/voting/index.ts
@@ -42,7 +42,21 @@ function randomSalt(): utils.BigNumber {
   return salt;
 }
 
+/**
+ * generateCommitMessage
+ *
+ * @param {string} commitHash keccak256(category + firstChoice + secondChoice ... + salt)
+ * @param {*} ballotChoices { firstChoice, secondChoice }
+ * @param {string} salt Random 256-bit number
+ */
+function generateCommitMessage(commitHash: string, ballotChoices: any, salt: string) {
+  return `Commit hash: ${commitHash}. First choice: ${ballotChoices.firstChoice}. Second choice: ${
+    ballotChoices.secondChoice
+  }. Salt: ${salt}`;
+}
+
 module.exports = {
   generateCommitHash,
   randomSalt,
+  generateCommitMessage,
 };


### PR DESCRIPTION
this pr adds support for client-side signing of string messages as well as backend routing and signature recovery. note: these tests run extremely slowly, likely due to the `beforeEach` statement in the tests re: ballots. near-future improvements can be made in this regard as well as for the serialization of commit messages: to-be-signed strings should be generated using `JSON.stringify(ballot)`.

- add string msg signing
- add `postBallot` client helper and corresponding api route
- add `generateCommitMessage` to panvala-utils
- prevent duplicate votes per epoch: add migration, update model
- add negative test for submitting invalid data (re: new constraint)
- specify ballot sig length and pattern (regex)

misc:
- add success and error toasts
- add custom `gasLimit` when executing `commitBallot`