### PR TITLE
Ethereum connection via route

### DIFF
--- a/client/__tests__/pages/ballots/vote.test.tsx
+++ b/client/__tests__/pages/ballots/vote.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { utils } from 'ethers';
 import { render, fireEvent, waitForElement } from 'react-testing-library';
 import 'jest-dom/extend-expect';
 
@@ -6,6 +7,7 @@ import Vote from '../../../pages/ballots/vote';
 import { slatesArray } from '../../../utils/data';
 import { AppContext } from '../../../components/Layout';
 import { BUTTON_COLORS, COLORS } from '../../../styles';
+import { EthereumContext } from '../../../components/EthereumProvider';
 
 const oneWeekSeconds = 604800;
 const epochStartDate = 1549040401;
@@ -23,7 +25,16 @@ const currentBallot = {
 const setup: any = () => {
   const { getByText, getByTestId, container } = render(
     <AppContext.Provider value={{ slates: slatesArray, currentBallot }}>
-      <Vote />
+      <EthereumContext.Provider
+        value={{
+          panBalance: utils.bigNumberify('0'),
+          gkAllowance: utils.bigNumberify('0'),
+          votingRights: utils.bigNumberify('0'),
+          onConnectEthereum: () => undefined,
+        }}
+      >
+        <Vote />
+      </EthereumContext.Provider>
     </AppContext.Provider>
   );
   const firstChoiceButton = getByText('1st Choice');

--- a/client/components/EthereumProvider.tsx
+++ b/client/components/EthereumProvider.tsx
@@ -20,15 +20,14 @@ export default class EthereumProvider extends React.Component<any, IEthereumCont
     panBalance: utils.bigNumberify('0'),
     gkAllowance: utils.bigNumberify('0'),
     votingRights: utils.bigNumberify('0'),
+    onConnectEthereum: () => this.handleConnectEthereum(),
   };
 
   componentWillUnmount() {
     console.log('unmounting..');
   }
 
-  // since componentDidMount will only run client-side,
-  // we'll be sure to have the window object here.
-  async componentDidMount() {
+  handleConnectEthereum = async () => {
     try {
       if (typeof window !== 'undefined' && window.hasOwnProperty('ethereum')) {
         // this means metamask is installed. get the ethereum provider
@@ -73,9 +72,9 @@ export default class EthereumProvider extends React.Component<any, IEthereumCont
       }
     } catch (error) {
       console.log(error);
-      // alert(`Error while attempting to connect to the Ethereum network... ${error.message}`);
+      toast.error('Error while attempting to connect to Ethereum.');
     }
-  }
+  };
 
   render() {
     console.log('ETH state:', this.state);

--- a/client/interfaces/contexts.ts
+++ b/client/interfaces/contexts.ts
@@ -84,9 +84,9 @@ export interface ISlateMetadata {
  * Slate data to be saved in the database
  */
 export interface ISaveSlate {
-  slateID: string,
-  metadataHash: string,
-  email?: string,
+  slateID: string;
+  metadataHash: string;
+  email?: string;
 }
 
 export interface IChoices {
@@ -135,4 +135,5 @@ export interface IEthereumContext {
   panBalance: utils.BigNumber;
   gkAllowance: utils.BigNumber;
   votingRights: utils.BigNumber;
+  onConnectEthereum?: any;
 }

--- a/client/pages/ballots/vote.tsx
+++ b/client/pages/ballots/vote.tsx
@@ -48,7 +48,12 @@ const Vote: React.FunctionComponent<IProps> = ({ router }) => {
     gkAllowance,
     votingRights,
     ethProvider,
+    onConnectEthereum,
   }: IEthereumContext = React.useContext(EthereumContext);
+
+  React.useEffect(() => {
+    onConnectEthereum();
+  }, []);
 
   // component state
   // choice selector

--- a/client/pages/slates/create.tsx
+++ b/client/pages/slates/create.tsx
@@ -25,6 +25,7 @@ import {
   IProposalMetadata,
   ISlateMetadata,
   ISaveSlate,
+  IEthereumContext,
 } from '../../interfaces';
 import { ipfsAddObject } from '../../utils/ipfs';
 import { LogDescription } from 'ethers/utils';
@@ -81,7 +82,13 @@ const CreateSlate: React.FunctionComponent<{ router: SingletonRouter }> = ({ rou
   const [isOpen, setOpenModal] = React.useState(false);
   // get proposals and eth context
   const { proposals, onRefreshSlates }: IAppContext = React.useContext(AppContext);
-  const { account, ethProvider, contracts }: any = React.useContext(EthereumContext);
+  const { account, ethProvider, contracts, onConnectEthereum }: IEthereumContext = React.useContext(
+    EthereumContext
+  );
+
+  React.useEffect(() => {
+    onConnectEthereum();
+  }, []);
 
   /**
    * getRequestIDs
@@ -447,5 +454,9 @@ const CreateSlate: React.FunctionComponent<{ router: SingletonRouter }> = ({ rou
   );
 };
 
+CreateSlate.getInitialProps = props => {
+  console.log('props:', props);
+  return props;
+};
 
 export default withRouter(CreateSlate);


### PR DESCRIPTION
previously the app would connect to mm/ethereum as soon as the app loaded. this pr moves that logic to the `/slates/create` and `/ballots/vote` routes.