### PR TITLE
Reveal ballots and count votes

### DIFF
--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -13,6 +13,7 @@ contract Gatekeeper {
     event SlateCreated(uint slateID, address indexed recommender, bytes metadataHash);
     event VotingTokensDeposited(address indexed voter, uint numTokens);
     event BallotCommitted(uint ballotID, address indexed voter, uint numTokens, bytes32 commitHash);
+    event BallotRevealed(uint ballotID, address indexed voter, uint numTokens);
 
     // STATE
     using SafeMath for uint256;
@@ -54,28 +55,51 @@ contract Gatekeeper {
     // The data committed when voting
     struct VoteCommitment {
         bytes32 commitHash;
+        uint numTokens;
         bool committed;
+        bool revealed;
     }
 
     // An option in a contest
     struct VoteOption {
         uint firstChoiceVotes;
-        uint secondChoiceVotes;
+        // slateID -> count
+        mapping(uint => uint) secondChoiceVotes;
         bool included;
     }
 
+    enum ContestStatus {
+        Empty,
+        NoContest,
+        Started, // Active
+        // Voting?
+        VoteFinalized,
+        RunoffRequired,
+        RunoffFinalized
+    }
+
     struct Contest {
+        ContestStatus status;
+
         // slateIDs
         uint[] slates;
 
         // slateID -> tally
         mapping(uint => VoteOption) options;
+
+        // Intermediate results
+        uint confidenceVoteWinner;
+        uint confidenceVoteRunnerUp;
+
+        // Final results
+        uint winner;
     }
 
     // A group of Contests in an epoch
     struct Ballot {
         // status: Unopened, Open, Closed
         uint contestCount;
+        // categoryID -> Contest
         mapping(uint => Contest) contests;
         bool created;
 
@@ -111,44 +135,57 @@ contract Gatekeeper {
         parameters = new ParameterStore(names, values);
     }
 
+    // TIMING
+    /**
+    * @dev Get the number of the current epoch.
+    */
+    function currentEpochNumber() public pure returns(uint) {
+        // uint elapsed = now.sub(startTime);
+        // uint epoch = elapsed.div(batchLength);
+
+        // return epoch;
+        return 0;
+    }
+
+    /**
+    * @dev Get the start of the current epoch.
+    */
+    function currentEpochStart() public view returns(uint) {
+        uint epoch = currentEpochNumber();
+        return startTime.add(batchLength.mul(epoch));
+    }
+
     /**
     * @dev Get the number of the current batch.
     */
     function currentBatchNumber() public view returns(uint) {
-        uint elapsed = now.sub(startTime);
-        uint batchNumber = elapsed.div(batchLength);
-
-        return batchNumber;
+        return currentEpochNumber();
     }
 
-    /**
-    * @dev Get the start of the current batch.
-    */
-    function currentBatchStart() public view returns(uint) {
-        uint batchNumber = currentBatchNumber();
-        return startTime.add(batchLength.mul(batchNumber));
-    }
 
     // SLATE GOVERNANCE
     /**
     * @dev Create a new slate with the associated requestIds and metadata hash.
     * @param batchNumber The batch to submit for
-    * @param category The category to submit the slate for
+    * @param categoryID The category to submit the slate for
     * @param requestIDs A list of request IDs to include in the slate
     * @param metadataHash A reference to metadata about the slate
     */
     function recommendSlate(
         uint batchNumber,
-        uint category,
+        uint categoryID,
         uint[] memory requestIDs,
         bytes memory metadataHash
     )
         public returns(uint)
     {
-        // NOTE: all requestIDs must be valid
-        // NOTE: category must be valid
-        // NOTE: batchNumber must be the current one
-        // NOTE: metadataHash must be valid
+        // TODO: batchNumber must be the current one
+        // TODO: category must be valid
+        // TODO: all requestIDs must be unique
+        for (uint i = 0; i < requestIDs.length; i++) {
+            require(requestIDs[i] < requestCount, "Invalid requestID");
+        }
+        require(metadataHash.length > 0, "metadataHash cannot be empty");
 
         // create slate
         Slate s = new Slate(msg.sender, metadataHash, requestIDs);
@@ -157,6 +194,17 @@ contract Gatekeeper {
         uint slateID = slateCount;
         slates[slateID] = s;
         slateCount = slateCount.add(1);
+
+        // Associate the slate with a contest and update the status
+        Contest storage c = ballots[batchNumber].contests[categoryID];
+        c.slates.push(slateID);
+
+        uint numSlates = c.slates.length;
+        if (numSlates == 1) {
+            c.status = ContestStatus.NoContest;
+        } else if (numSlates > 1) {
+            c.status = ContestStatus.Started;
+        }
 
         emit SlateCreated(slateID, msg.sender, metadataHash);
         return slateID;
@@ -184,6 +232,7 @@ contract Gatekeeper {
         return true;
     }
 
+
     /**
      @dev Submit a commitment for the current ballot
      @param commitHash The hash representing the voter's vote choices
@@ -192,11 +241,9 @@ contract Gatekeeper {
     function commitBallot(bytes32 commitHash, uint numTokens) public {
         address voter = msg.sender;
 
-        // TODO: calculate the current epoch
-        uint currentEpoch = 0;
-        uint ballotID = currentEpoch;
+        uint ballotID = currentEpochNumber();
 
-        // NOTE: commit period must be active for the given epoch
+        // TODO: timing: commit period must be active for the given epoch
         require(didCommit(ballotID, voter) == false, "Voter has already committed for this ballot");
         require(commitHash != 0, "Cannot commit zero hash");
 
@@ -213,7 +260,9 @@ contract Gatekeeper {
         // Set the voter's commitment for the current ballot
         VoteCommitment memory commitment = VoteCommitment({
             commitHash: commitHash,
-            committed: true
+            numTokens: numTokens,
+            committed: true,
+            revealed: false
         });
 
         ballot.commitments[voter] = commitment;
@@ -240,6 +289,116 @@ contract Gatekeeper {
         require(v.committed, "Voter has not committed for this ballot");
 
         return v.commitHash;
+    }
+
+
+    /**
+     @dev Reveal a given voter's choices for the current ballot
+     @param voter The voter's address
+     @param categories The contests to vote on
+     @param firstChoices The corresponding first choices
+     @param secondChoices The corresponding second choices
+     @param salt The salt used to generate the original commitment
+     */
+    function revealBallot(
+        address voter,
+        uint[] memory categories,
+        uint[] memory firstChoices,
+        uint[] memory secondChoices,
+        uint salt
+    ) public {
+        uint ballotID = currentEpochNumber();
+
+        require(voter != address(0), "Voter address cannot be zero");
+        require(didCommit(ballotID, voter), "Voter has not committed for this ballot");
+        require(categories.length == firstChoices.length, "All inputs must have the same length");
+        require(firstChoices.length == secondChoices.length, "All inputs must have the same length");
+        // TODO: cannot reveal twice
+
+        // TODO: timing: must be in reveal period
+
+        // calculate the hash
+        bytes memory buf;
+        uint votes = categories.length;
+        for (uint i = 0; i < votes; i++) {
+            buf = abi.encodePacked(
+                buf,
+                categories[i],
+                firstChoices[i],
+                secondChoices[i]
+            );
+        }
+        buf = abi.encodePacked(buf, salt);
+        bytes32 hashed = keccak256(buf);
+
+        Ballot storage ballot = ballots[ballotID];
+
+        // compare to the stored data
+        VoteCommitment memory v = ballot.commitments[voter];
+        require(hashed == v.commitHash, "Submitted ballot does not match commitment");
+
+        // Update tally for each contest
+        for (uint i = 0; i < votes; i++) {
+            uint category = categories[i];
+
+            // get the contest for the current category
+            Contest storage contest = ballot.contests[category];
+
+            // Increment totals for first and second choice slates
+            uint firstChoice = firstChoices[i];
+            VoteOption storage option = contest.options[firstChoice];
+            option.firstChoiceVotes = option.firstChoiceVotes.add(v.numTokens);
+
+            uint secondChoice = secondChoices[i];
+            option.secondChoiceVotes[secondChoice] = option.secondChoiceVotes[secondChoice].add(v.numTokens);
+        }
+
+        // update state
+        ballot.commitments[voter].revealed = true;
+
+        emit BallotRevealed(ballotID, voter, v.numTokens);
+    }
+
+    /**
+     @dev Get the number of first-choice votes cast in the ballot for the given slate and category
+     @param ballotID The ballot
+     @param categoryID The category
+     @param slateID The slate
+     */
+    function getFirstChoiceVotes(uint ballotID, uint categoryID, uint slateID) public view returns(uint) {
+        VoteOption storage v = ballots[ballotID].contests[categoryID].options[slateID];
+        return v.firstChoiceVotes;
+    }
+
+    function getSecondChoiceVotes(uint ballotID, uint categoryID, uint slateID) public view returns(uint) {
+        // for each option that isn't this one, get the second choice votes
+        Contest storage contest = ballots[ballotID].contests[categoryID];
+        uint numSlates = contest.slates.length;
+        uint votes = 0;
+        for (uint i = 0; i < numSlates; i++) {
+            uint otherSlateID = contest.slates[i];
+            // if (otherSlateID != slateID) {
+                VoteOption storage v = contest.options[otherSlateID];
+                // get second-choice votes for the target slate
+                votes = votes.add(v.secondChoiceVotes[slateID]);
+            // }
+        }
+        return votes;
+    }
+
+    /**
+     @dev Return true if the voter has revealed for the given ballot
+     @param ballotID The ballot
+     @param voter The voter's address
+     */
+    function didReveal(uint ballotID, address voter) public view returns(bool) {
+        return ballots[ballotID].commitments[voter].revealed;
+    }
+    /**
+     @dev Return the status of the specified contest
+     */
+    function contestStatus(uint ballotID, uint categoryID) public view returns(ContestStatus) {
+        return ballots[ballotID].contests[categoryID].status;
     }
 
     // ACCESS CONTROL

--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -12,8 +12,8 @@ contract Gatekeeper {
     event PermissionRequested(uint requestID, bytes metadataHash);
     event SlateCreated(uint slateID, address indexed recommender, bytes metadataHash);
     event VotingTokensDeposited(address indexed voter, uint numTokens);
-    event BallotCommitted(uint ballotID, address indexed voter, uint numTokens, bytes32 commitHash);
-    event BallotRevealed(uint ballotID, address indexed voter, uint numTokens);
+    event BallotCommitted(uint indexed ballotID, address indexed voter, uint numTokens, bytes32 commitHash);
+    event BallotRevealed(uint indexed ballotID, address indexed voter, uint numTokens);
     event ConfidenceVoteCounted(
         uint indexed ballotID,
         uint indexed categoryID,
@@ -385,6 +385,28 @@ contract Gatekeeper {
         ballot.commitments[voter].revealed = true;
 
         emit BallotRevealed(ballotID, voter, v.numTokens);
+    }
+
+    /**
+    @dev Reveal ballots for multiple voters
+     */
+    function revealManyBallots(
+        address[] memory _voters,
+        bytes[] memory _ballots,
+        uint[] memory _salts
+    ) public {
+        uint numBallots = _voters.length;
+
+        for (uint i = 0; i < numBallots; i++) {
+            // extract categories, firstChoices, secondChoices from the ballot
+            (
+                uint[] memory categories,
+                uint[] memory firstChoices,
+                uint[] memory secondChoices
+            ) = abi.decode(_ballots[i], (uint[], uint[], uint[]));
+
+            revealBallot(_voters[i], categories, firstChoices, secondChoices, _salts[i]);
+        }
     }
 
     /**

--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -22,6 +22,7 @@ contract Gatekeeper {
         uint totalVotes
     );
     event ConfidenceVoteFinalized(uint indexed ballotID, uint indexed categoryID, uint winningSlate);
+    event ConfidenceVoteFailed(uint indexed ballotID, uint categoryID);
     event RunoffStarted(uint indexed ballotID, uint indexed categoryID, uint winningSlate, uint runnerUpSlate);
     event RunoffCounted(
         uint indexed ballotID,
@@ -521,6 +522,7 @@ contract Gatekeeper {
         } else {
             rejectEliminatedSlates(ballotID, categoryID);
             updatedContest.status = ContestStatus.RunoffPending;
+            emit ConfidenceVoteFailed(ballotID, categoryID);
         }
     }
 

--- a/governance-contracts/package.json
+++ b/governance-contracts/package.json
@@ -22,6 +22,7 @@
         "eslint": "5.6.1",
         "eslint-config-airbnb-base": "13.1.0",
         "eslint-plugin-import": "2.14.0",
+        "ethers": "^4.0.27",
         "solhint": "1.3.0",
         "solidity-coverage": "0.5.11",
         "truffle": "^5.0.4"

--- a/governance-contracts/test/gatekeeper.js
+++ b/governance-contracts/test/gatekeeper.js
@@ -1235,7 +1235,7 @@ contract('Gatekeeper', (accounts) => {
 
       // Check logs
       const receipt = await gatekeeper.countVotes(ballotID, GRANT);
-      assert.strictEqual(receipt.logs.length, 1, 'Only one event should have been emitted');
+      utils.expectEvents(receipt, ['ConfidenceVoteCounted', 'ConfidenceVoteFailed']);
 
       // Should be waiting for a runoff
       const status = await gatekeeper.contestStatus(ballotID, GRANT);
@@ -1259,7 +1259,7 @@ contract('Gatekeeper', (accounts) => {
 
       // Check logs
       const receipt = await gatekeeper.countVotes(ballotID, GRANT);
-      assert.strictEqual(receipt.logs.length, 1, 'Only one event should have been emitted');
+      utils.expectEvents(receipt, ['ConfidenceVoteCounted', 'ConfidenceVoteFailed']);
 
       // Should be waiting for a runoff
       const status = await gatekeeper.contestStatus(ballotID, GRANT);

--- a/governance-contracts/test/gatekeeper.js
+++ b/governance-contracts/test/gatekeeper.js
@@ -19,7 +19,7 @@ const ContestStatus = {
   NoContest: '1',
   Started: '2',
   VoteFinalized: '3',
-  RunoffRequired: '4',
+  RunoffPending: '4',
   RunoffFinalized: '5',
 };
 
@@ -721,6 +721,8 @@ contract('Gatekeeper', (accounts) => {
       assert.fail('Revealed for a voter who has not committed for the ballot');
     });
 
+    it('should fail if the voter has already revealed for the ballot');
+
     it('should fail if the reveal period has not started');
     it('should fail if the reveal period has ended');
   });
@@ -961,9 +963,6 @@ contract('Gatekeeper', (accounts) => {
       assert.fail('Tallied votes for a category with no competition');
     });
 
-    // it('should finalize the vote if one of the slates has a majority');
-
-    // runoff
     it('should wait for a runoff if no slate has more than 50% of the votes', async () => {
       // Add a third slate
       await utils.newSlate(gatekeeper, {
@@ -991,8 +990,8 @@ contract('Gatekeeper', (accounts) => {
       const status = await gatekeeper.contestStatus(ballotID, GRANT);
       assert.strictEqual(
         status.toString(),
-        ContestStatus.RunoffRequired,
-        'Contest status should have been RunoffRequired',
+        ContestStatus.RunoffPending,
+        'Contest status should have been RunoffPending',
       );
     });
 
@@ -1015,8 +1014,8 @@ contract('Gatekeeper', (accounts) => {
       const status = await gatekeeper.contestStatus(ballotID, GRANT);
       assert.strictEqual(
         status.toString(),
-        ContestStatus.RunoffRequired,
-        'Contest status should have been RunoffRequired',
+        ContestStatus.RunoffPending,
+        'Contest status should have been RunoffPending',
       );
     });
   });

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -21,6 +21,20 @@ function expectRevert(error) {
   );
 }
 
+/**
+ * Assert that the receipt contains the expected events
+ * @param {TransactionReceipt} receipt
+ * @param {Array} eventNames
+ */
+function expectEvents(receipt, eventNames) {
+  // const actualEventNames = receipt.logs.map(l => l.event);
+  assert.deepStrictEqual(
+    receipt.logs.map(l => l.event),
+    eventNames,
+    `Incorrect events emitted -- expected ${eventNames}`,
+  );
+}
+
 function createMultihash(data) {
   const digest = ethUtils.sha256(data);
 
@@ -292,6 +306,7 @@ const SlateStatus = {
 
 const utils = {
   expectRevert,
+  expectEvents,
   zeroAddress: ethUtils.zeroAddress,
   BN: ethUtils.BN,
   createMultihash,

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -1,11 +1,14 @@
 /* globals artifacts assert */
 const ethUtils = require('ethereumjs-util');
 const bs58 = require('bs58');
+const ethers = require('ethers');
+
 
 const Gatekeeper = artifacts.require('Gatekeeper');
 const BasicToken = artifacts.require('BasicToken');
 
 const { BN } = ethUtils;
+const { solidityKeccak256 } = ethers.utils;
 
 /**
  * Check that the error is an EVM `revert`
@@ -112,6 +115,56 @@ function zeroHash() {
   return ethUtils.zeros(32);
 }
 
+
+/**
+ * generateCommitHash
+ * keccak256(category + firstChoice + secondChoice ... + salt)
+ * @param {*} votes { category: { firstChoice, secondChoice }}
+ * @param {ethUtils.BN} salt Random 256-bit number
+ */
+function generateCommitHash(votes, salt) {
+  const types = [];
+  const values = [];
+
+  Object.keys(votes).forEach((category) => {
+    const { firstChoice, secondChoice } = votes[category];
+    types.push('uint', 'uint', 'uint');
+    values.push(category, firstChoice, secondChoice);
+  });
+  types.push('uint');
+  values.push(salt);
+
+  // const packed = ethers.utils.solidityPack(types, values);
+  // console.log(packed);
+  return solidityKeccak256(types, values);
+}
+
+async function getRequestIDs(gatekeeper, proposalData, options) {
+  // console.log(options);
+  options = options || {};
+
+  const metadataHashes = proposalData.map(createMultihash);
+  const requests = metadataHashes.map(md => gatekeeper.requestPermission(
+    asBytes(md),
+    options,
+  ));
+
+  const receipts = await Promise.all(requests);
+  const requestIDs = receipts.map((receipt) => {
+    const { requestID } = receipt.logs[0].args;
+    return requestID;
+  });
+
+  return requestIDs;
+}
+
+async function newSlate(gatekeeper, data, options) {
+  const { batchNumber, category, proposalData, slateData } = data;
+  const requestIDs = await getRequestIDs(gatekeeper, proposalData, options);
+
+  await gatekeeper.recommendSlate(batchNumber, category, requestIDs, asBytes(slateData), options);
+  return requestIDs;
+}
 const utils = {
   expectRevert,
   zeroAddress: ethUtils.zeroAddress,
@@ -124,6 +177,9 @@ const utils = {
   newToken,
   keccak: ethUtils.keccak,
   zeroHash,
+  generateCommitHash,
+  getRequestIDs,
+  newSlate,
 };
 
 module.exports = utils;

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -147,12 +147,12 @@ function generateCommitHash(votes, salt) {
  */
 async function getRequestIDs(gatekeeper, proposalData, options) {
   // console.log(options);
-  options = options || {};
+  const txOptions = options || {};
 
   const metadataHashes = proposalData.map(createMultihash);
   const requests = metadataHashes.map(md => gatekeeper.requestPermission(
     asBytes(md),
-    options,
+    txOptions,
   ));
 
   const receipts = await Promise.all(requests);
@@ -165,7 +165,9 @@ async function getRequestIDs(gatekeeper, proposalData, options) {
 }
 
 async function newSlate(gatekeeper, data, options) {
-  const { batchNumber, category, proposalData, slateData } = data;
+  const {
+    batchNumber, category, proposalData, slateData,
+  } = data;
   const requestIDs = await getRequestIDs(gatekeeper, proposalData, options);
 
   await gatekeeper.recommendSlate(batchNumber, category, requestIDs, asBytes(slateData), options);
@@ -206,11 +208,30 @@ async function voteSingle(gatekeeper, voter, category, firstChoice, secondChoice
  * @param {*} revealData
  */
 async function revealVote(gatekeeper, revealData) {
-  const { voter, categories, firstChoices, secondChoices, salt } = revealData;
+  const {
+    voter, categories, firstChoices, secondChoices, salt,
+  } = revealData;
   await gatekeeper.revealBallot(
-    voter, categories, firstChoices, secondChoices, salt, { from: voter });
+    voter, categories, firstChoices, secondChoices, salt, { from: voter },
+  );
 }
 
+
+const ContestStatus = {
+  Empty: '0',
+  NoContest: '1',
+  Started: '2',
+  VoteFinalized: '3',
+  RunoffPending: '4',
+  RunoffFinalized: '5',
+};
+
+const SlateStatus = {
+  Unstaked: '0',
+  Staked: '1',
+  Rejected: '2',
+  Accepted: '3',
+};
 
 const utils = {
   expectRevert,
@@ -229,6 +250,8 @@ const utils = {
   newSlate,
   voteSingle,
   revealVote,
+  ContestStatus,
+  SlateStatus,
 };
 
 module.exports = utils;

--- a/governance-contracts/yarn.lock
+++ b/governance-contracts/yarn.lock
@@ -18,6 +18,11 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@types/node@^10.3.2":
+  version "10.14.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.1.tgz#8701cd760acc20beba5ffe0b7a1b879f39cb8c41"
+  integrity sha512-Rymt08vh1GaW4vYB6QP61/5m/CFLGnFZP++bJpWbiNxceNa6RBipDmb413jvtSf/R1gg5a/jQVl2jY4XVRscEA==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -54,6 +59,11 @@ acorn@^6.0.2:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
+
+aes-js@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
+  integrity sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=
 
 ajv-keywords@^2.1.0:
   version "2.1.1"
@@ -534,6 +544,16 @@ drbg.js@^1.0.1:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
 
+elliptic@6.3.3:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.3.3.tgz#5482d9646d54bcb89fd7d994fc9e2e9568876e3f"
+  integrity sha1-VILZZG1UvLif19mU/J4ulWiHbj8=
+  dependencies:
+    bn.js "^4.4.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    inherits "^2.0.1"
+
 elliptic@^6.2.3:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
@@ -828,6 +848,22 @@ ethereumjs-util@^6.1.0:
     safe-buffer "^5.1.1"
     secp256k1 "^3.0.1"
 
+ethers@^4.0.27:
+  version "4.0.27"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.27.tgz#e570b0da9d805ad65c83d81919abe02b2264c6bf"
+  integrity sha512-+DXZLP/tyFnXWxqr2fXLT67KlGUfLuvDkHSOtSC9TUVG9OIj6yrG5JPeXRMYo15xkOYwnjgdMKrXp5V94rtjJA==
+  dependencies:
+    "@types/node" "^10.3.2"
+    aes-js "3.0.0"
+    bn.js "^4.4.0"
+    elliptic "6.3.3"
+    hash.js "1.1.3"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.4"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
+
 ethjs-util@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
@@ -1079,6 +1115,14 @@ hash-base@^3.0.0:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+hash.js@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.3.tgz#340dedbe6290187151c1ea1d777a3448935df846"
+  integrity sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.0"
+
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
@@ -1290,6 +1334,11 @@ istanbul@^0.4.5:
     supports-color "^3.1.0"
     which "^1.1.1"
     wordwrap "^1.0.0"
+
+js-sha3@0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
+  integrity sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
 
 js-sha3@^0.6.1:
   version "0.6.1"
@@ -1986,6 +2035,11 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, 
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+scrypt-js@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
+  integrity sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==
+
 secp256k1@^3.0.1:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.6.2.tgz#da835061c833c74a12f75c73d2ec2e980f00dc1f"
@@ -2009,6 +2063,11 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+setimmediate@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.4.tgz#20e81de622d4a02588ce0c8da8973cbcf1d3138f"
+  integrity sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"
@@ -2377,6 +2436,11 @@ util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
+uuid@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.1.tgz#c2a30dedb3e535d72ccf82e343941a50ba8533ac"
+  integrity sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -2463,7 +2527,7 @@ xhr2@*:
   resolved "https://registry.yarnpkg.com/xhr2/-/xhr2-0.1.4.tgz#7f87658847716db5026323812f818cadab387a5f"
   integrity sha1-f4dliEdxbbUCYyOBL4GMras4el8=
 
-xmlhttprequest@*:
+xmlhttprequest@*, xmlhttprequest@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
   integrity sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=


### PR DESCRIPTION
This PR implements ballot revealing and vote counting, including runoff vote counting.

If after the first vote count, one slate has at least 50%, the contest's status is set to `VoteFinalized`. Otherwise, the contest's status is set to `RunoffPending`, and a runoff can be triggered. In the runoff, all slates other than the top two from the first count are eliminated. Next, any second choice votes for the top two from voters whose first choice was eliminated are added to the original count. The slate with the most votes wins, or if they are tied, the one with the lowest ID (the one submitted first) wins.

Some new `Gatekeeper` functions of interest include:
- actions:
  - `revealBallot()` / `revealManyBallots()`
  - `countVotes()`
  - `countRunoffVotes()`
- queries:
  - `contestStatus()`
  - `getWinningSlate()`
  - `hasPermission()`

Some new `Slate` functions of interest:
- actions:
  - `markAccepted()`
  - `markRejected()`
- queries:
  - `getRequests()`