### PR TITLE
Staked slates on the ballot

### DIFF
--- a/api/scripts/tally-votes.js
+++ b/api/scripts/tally-votes.js
@@ -19,8 +19,16 @@ async function tally(gatekeeper, ballotID, categoryID) {
   let status = await gatekeeper.functions.contestStatus(ballotID, categoryID);
   // console.log('status', status);
 
-  if (status.toString() === ContestStatus.Started) {
-    console.log('counting votes for ballotID, categoryID, status', ballotID, categoryID, status);
+  if (status.toString() === ContestStatus.NoContest) {
+    console.log(`No challenger for categoryID ${categoryID} -- automatically finalizing`);
+    await gatekeeper.functions.countVotes(ballotID, categoryID);
+
+    status = await gatekeeper.functions.contestStatus(ballotID, categoryID);
+    console.log('new status', status);
+  }
+
+  if (status.toString() === ContestStatus.Active) {
+    console.log('Counting votes for ballotID, categoryID, status', ballotID, categoryID, status);
     await gatekeeper.functions.countVotes(ballotID, categoryID);
     console.log('counted votes!');
 
@@ -29,6 +37,7 @@ async function tally(gatekeeper, ballotID, categoryID) {
   }
 
   if (status.toString() === ContestStatus.RunoffPending) {
+    console.log(`Counting runoff votes for category ${categoryID}`);
     await gatekeeper.functions.countRunoffVotes(ballotID, categoryID);
   }
 }

--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -565,7 +565,8 @@ contract Gatekeeper {
      */
     function countVotes(uint ballotID, uint categoryID) public {
         // TODO: revert if categoryID is invalid
-        // TODO: revert if the ballot doesn't have a contest for this category
+
+        // Make sure the ballot has a contest for this category
         Contest memory contest = ballots[ballotID].contests[categoryID];
         require(contest.status == ContestStatus.Active || contest.status == ContestStatus.NoContest,
             "No contest is in progress for this category");
@@ -584,7 +585,7 @@ contract Gatekeeper {
             return;
         }
 
-        // TODO: timing: must be after the vote period
+        // TODO: timing: non-automatic finalization must be after the vote period
 
         // Iterate through the slates and get the one with the most votes
         uint winner = 0;

--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -270,6 +270,7 @@ contract Gatekeeper {
      */
     function stakeTokens(uint slateID) public returns(bool) {
         require(slateID < slateCount, "No slate exists with that slateID");
+        require(slates[slateID].status == SlateStatus.Unstaked, "Slate has already been staked");
 
         address staker = msg.sender;
         IERC20 token = token();

--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -196,20 +196,19 @@ contract Gatekeeper {
     // SLATE GOVERNANCE
     /**
     * @dev Create a new slate with the associated requestIds and metadata hash.
-    * @param batchNumber The batch to submit for
     * @param categoryID The category to submit the slate for
     * @param requestIDs A list of request IDs to include in the slate
     * @param metadataHash A reference to metadata about the slate
     */
     function recommendSlate(
-        uint batchNumber,
         uint categoryID,
         uint[] memory requestIDs,
         bytes memory metadataHash
     )
         public returns(uint)
     {
-        // TODO: timing: batchNumber must be the current one
+        uint256 epochNumber = currentEpochNumber();
+
         // TODO: category must be valid
         // TODO: timing: the slate submission period must be active for the given epoch
         require(metadataHash.length > 0, "metadataHash cannot be empty");

--- a/governance-contracts/test/gatekeeper.js
+++ b/governance-contracts/test/gatekeeper.js
@@ -1434,8 +1434,8 @@ contract('Gatekeeper', (accounts) => {
       const status = await gatekeeper.contestStatus(ballotID, GRANT);
       assert.strictEqual(
         status.toString(),
-        ContestStatus.VoteFinalized,
-        'Contest status should have been VoteFinalized',
+        ContestStatus.Finalized,
+        'Contest status should have been Finalized',
       );
 
       // Winning slate should have status Accepted
@@ -1515,12 +1515,12 @@ contract('Gatekeeper', (accounts) => {
         'Slate should have been accepted',
       );
 
-      // Contest should be AutomaticallyFinalized
+      // Contest should be Finalized
       const contestStatus = await gatekeeper.contestStatus(ballotID, GOVERNANCE);
       assert.strictEqual(
         contestStatus.toString(),
-        ContestStatus.AutomaticallyFinalized,
-        'Contest should have been automatically finalized',
+        ContestStatus.Finalized,
+        'Contest should have status Finalized',
       );
     });
 
@@ -1690,7 +1690,7 @@ contract('Gatekeeper', (accounts) => {
       );
     });
 
-    it('should return Started if the category has two or more slates', async () => {
+    it('should return Active if the category has two or more slates', async () => {
       await utils.newSlate(gatekeeper, {
         batchNumber: ballotID,
         category: GRANT,
@@ -1710,8 +1710,8 @@ contract('Gatekeeper', (accounts) => {
 
       assert.strictEqual(
         status.toString(),
-        ContestStatus.Started,
-        'Contest status should have been Started',
+        ContestStatus.Active,
+        'Contest status should have been Active',
       );
     });
 
@@ -1816,12 +1816,12 @@ contract('Gatekeeper', (accounts) => {
 
       assert.strictEqual(winningSlate.toString(), expectedWinner, 'Runoff finalized with wrong winner');
 
-      // status should be RunoffFinalized at the end
+      // status should be Finalized at the end
       const status = await gatekeeper.contestStatus(ballotID, GRANT);
       assert.strictEqual(
         status.toString(),
-        ContestStatus.RunoffFinalized,
-        'Contest status should have been RunoffFinalized',
+        ContestStatus.Finalized,
+        'Contest status should have been Finalized',
       );
 
       // Winning slate should have status Accepted
@@ -1930,7 +1930,7 @@ contract('Gatekeeper', (accounts) => {
       await gatekeeper.countVotes(ballotID, GRANT);
 
       const status = await gatekeeper.contestStatus(ballotID, GRANT);
-      assert.strictEqual(status.toString(), ContestStatus.VoteFinalized);
+      assert.strictEqual(status.toString(), ContestStatus.Finalized);
 
       // Runoff
       try {

--- a/governance-contracts/test/gatekeeper.js
+++ b/governance-contracts/test/gatekeeper.js
@@ -437,6 +437,22 @@ contract('Gatekeeper', (accounts) => {
       }
       assert.fail('Staked even though token transfer failed');
     });
+
+    it('should revert if the slate has already been staked on', async () => {
+      await token.transfer(staker, '10000', { from: creator });
+      await token.approve(gatekeeper.address, '10000', { from: staker });
+
+      await gatekeeper.stakeTokens(slateID, { from: staker });
+
+      try {
+        await gatekeeper.stakeTokens(slateID, { from: staker });
+      } catch (error) {
+        expectRevert(error);
+        expectErrorLike(error, 'already been staked');
+        return;
+      }
+      assert.fail('Allowed a slate to be staked multiple times');
+    });
   });
 
   describe('requestPermission', () => {

--- a/governance-contracts/test/gatekeeper.js
+++ b/governance-contracts/test/gatekeeper.js
@@ -206,7 +206,6 @@ contract('Gatekeeper', (accounts) => {
 
       // Create a slate
       const receipt = await gatekeeper.recommendSlate(
-        batchNumber,
         category,
         requestIDs,
         utils.asBytes(metadataHash),
@@ -253,7 +252,6 @@ contract('Gatekeeper', (accounts) => {
 
       // Create a slate
       const receipt = await gatekeeper.recommendSlate(
-        batchNumber,
         category,
         noRequests,
         utils.asBytes(metadataHash),
@@ -271,7 +269,6 @@ contract('Gatekeeper', (accounts) => {
 
       try {
         await gatekeeper.recommendSlate(
-          batchNumber,
           category,
           requestIDs,
           utils.asBytes(emptyHash),
@@ -290,7 +287,6 @@ contract('Gatekeeper', (accounts) => {
 
       try {
         await gatekeeper.recommendSlate(
-          batchNumber,
           category,
           invalidRequestIDs,
           utils.asBytes(metadataHash),
@@ -310,7 +306,6 @@ contract('Gatekeeper', (accounts) => {
 
       try {
         await gatekeeper.recommendSlate(
-          batchNumber,
           category,
           invalidRequestIDs,
           utils.asBytes(metadataHash),
@@ -324,7 +319,6 @@ contract('Gatekeeper', (accounts) => {
       assert.fail('Recommended a slate with duplicate requestIDs');
     });
 
-    it('should revert if the batchNumber is wrong');
     it('should revert if the category is invalid');
   });
 
@@ -858,14 +852,12 @@ contract('Gatekeeper', (accounts) => {
       // New slates 0, 1
       // grant
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'c'],
         slateData: 'my slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'd'],
         slateData: 'competing slate',
@@ -874,14 +866,12 @@ contract('Gatekeeper', (accounts) => {
       // New slates 2, 3
       // governance
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GOVERNANCE,
         proposalData: ['e', 'f', 'g'],
         slateData: 'governance slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['g', 'h', 'i'],
         slateData: 'competing slate',
@@ -1166,14 +1156,12 @@ contract('Gatekeeper', (accounts) => {
       // New slates 0, 1
       // grant
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'c'],
         slateData: 'grant slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'd'],
         slateData: 'competing slate',
@@ -1182,14 +1170,12 @@ contract('Gatekeeper', (accounts) => {
       // New slates 2, 3
       // governance
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GOVERNANCE,
         proposalData: ['e', 'f', 'g'],
         slateData: 'governance slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['g', 'h', 'i'],
         slateData: 'competing slate',
@@ -1276,14 +1262,12 @@ contract('Gatekeeper', (accounts) => {
 
       // grant - slates 0, 1
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'c'],
         slateData: 'my slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'd'],
         slateData: 'competing slate',
@@ -1291,14 +1275,12 @@ contract('Gatekeeper', (accounts) => {
 
       // governance - slates 2, 3
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GOVERNANCE,
         proposalData: ['e', 'f', 'g'],
         slateData: 'governance slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['g', 'h', 'i'],
         slateData: 'competing slate',
@@ -1385,14 +1367,12 @@ contract('Gatekeeper', (accounts) => {
 
       // create simple ballot with just grants
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'c'],
         slateData: 'my slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'd'],
         slateData: 'competing slate',
@@ -1503,7 +1483,6 @@ contract('Gatekeeper', (accounts) => {
 
       // Add a new governance slate
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GOVERNANCE,
         proposalData: ['e', 'f', 'g'],
         slateData: 'governance slate',
@@ -1543,7 +1522,6 @@ contract('Gatekeeper', (accounts) => {
     it('should wait for a runoff if no slate has more than 50% of the votes', async () => {
       // Add a third slate
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['h', 'i', 'j'],
         slateData: 'yet another slate',
@@ -1623,21 +1601,18 @@ contract('Gatekeeper', (accounts) => {
 
       // create simple ballot with just grants
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'c'],
         slateData: 'my slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'd'],
         slateData: 'competing slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['e', 'f', 'g'],
         slateData: 'competing slate',
@@ -1691,7 +1666,6 @@ contract('Gatekeeper', (accounts) => {
 
     it('should return NoContest if the category has only a single slate', async () => {
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'c'],
         slateData: 'my slate',
@@ -1708,14 +1682,12 @@ contract('Gatekeeper', (accounts) => {
 
     it('should return Active if the category has two or more slates', async () => {
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'c'],
         slateData: 'my slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'd'],
         slateData: 'competing slate',
@@ -1749,21 +1721,18 @@ contract('Gatekeeper', (accounts) => {
 
       // create simple ballot with just grants
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'c'],
         slateData: 'my slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'd'],
         slateData: 'competing slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['h', 'i', 'j'],
         slateData: 'yet another slate',
@@ -1974,21 +1943,18 @@ contract('Gatekeeper', (accounts) => {
 
       // create simple ballot with just grants
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'c'],
         slateData: 'my slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'd'],
         slateData: 'competing slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['h', 'i', 'j'],
         slateData: 'yet another slate',
@@ -2084,7 +2050,6 @@ contract('Gatekeeper', (accounts) => {
       // create simple ballot with just grants
       // contains requests 0, 1, 2
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'c'],
         slateData: 'my slate',
@@ -2092,7 +2057,6 @@ contract('Gatekeeper', (accounts) => {
 
       // contains requests 3, 4, 5
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'd'],
         slateData: 'competing slate',
@@ -2100,7 +2064,6 @@ contract('Gatekeeper', (accounts) => {
 
       // contains requests 6, 7, 8
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['e', 'f', 'g'],
         slateData: 'competing slate',
@@ -2190,21 +2153,18 @@ contract('Gatekeeper', (accounts) => {
 
       // create simple ballot with just grants
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'c'],
         slateData: 'my slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'd'],
         slateData: 'competing slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['h', 'i', 'j'],
         slateData: 'yet another slate',
@@ -2457,21 +2417,18 @@ contract('Gatekeeper', (accounts) => {
 
       // create simple ballot with just grants
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'c'],
         slateData: 'my slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['a', 'b', 'd'],
         slateData: 'competing slate',
       }, { from: recommender });
 
       await utils.newSlate(gatekeeper, {
-        batchNumber: ballotID,
         category: GRANT,
         proposalData: ['h', 'i', 'j'],
         slateData: 'yet another slate',

--- a/governance-contracts/test/tokenCapacitor.js
+++ b/governance-contracts/test/tokenCapacitor.js
@@ -263,7 +263,6 @@ contract('TokenCapacitor', (accounts) => {
         capacitor,
         recommender: recommender1,
         metadata: 'slate 1',
-        batchNumber: ballotID,
       });
 
       proposals2 = [
@@ -276,7 +275,6 @@ contract('TokenCapacitor', (accounts) => {
         capacitor,
         recommender: recommender2,
         metadata: 'slate 2',
-        batchNumber: ballotID,
       });
 
 

--- a/governance-contracts/test/tokenCapacitor.js
+++ b/governance-contracts/test/tokenCapacitor.js
@@ -242,7 +242,7 @@ contract('TokenCapacitor', (accounts) => {
       await token.transfer(capacitor.address, capacitorSupply, { from: creator });
 
       // Allocate tokens
-      const allocatedTokens = '1000';
+      const allocatedTokens = '10000';
       await token.transfer(alice, allocatedTokens, { from: creator });
       await token.transfer(bob, allocatedTokens, { from: creator });
       await token.transfer(carol, allocatedTokens, { from: creator });
@@ -277,6 +277,13 @@ contract('TokenCapacitor', (accounts) => {
         metadata: 'slate 2',
       });
 
+      await token.transfer(recommender1, allocatedTokens, { from: creator });
+      await token.approve(gatekeeper.address, allocatedTokens, { from: recommender1 });
+      await token.transfer(recommender2, allocatedTokens, { from: creator });
+      await token.approve(gatekeeper.address, allocatedTokens, { from: recommender2 });
+
+      await gatekeeper.stakeTokens(0, { from: recommender1 });
+      await gatekeeper.stakeTokens(1, { from: recommender2 });
 
       // Commit ballots
       const aliceReveal = await voteSingle(gatekeeper, alice, GRANT, 0, 1, '1000', '1234');

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -224,7 +224,7 @@ const proposalCategories = {
  */
 async function grantSlateFromProposals(options) {
   const {
-    gatekeeper, capacitor, proposals, recommender, metadata, batchNumber,
+    gatekeeper, capacitor, proposals, recommender, metadata,
   } = options;
   const beneficiaries = [];
   const tokenAmounts = [];
@@ -245,7 +245,6 @@ async function grantSlateFromProposals(options) {
   const requestIDs = receipt.logs.map(l => l.args.requestID);
 
   await gatekeeper.recommendSlate(
-    batchNumber,
     proposalCategories.GRANT,
     requestIDs,
     asBytes(metadata),
@@ -282,11 +281,11 @@ async function getRequestIDs(gatekeeper, proposalData, options) {
 
 async function newSlate(gatekeeper, data, options) {
   const {
-    batchNumber, category, proposalData, slateData,
+    category, proposalData, slateData,
   } = data;
   const requestIDs = await getRequestIDs(gatekeeper, proposalData, options);
 
-  await gatekeeper.recommendSlate(batchNumber, category, requestIDs, asBytes(slateData), options);
+  await gatekeeper.recommendSlate(category, requestIDs, asBytes(slateData), options);
   return requestIDs;
 }
 

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -397,6 +397,7 @@ const ContestStatus = {
   VoteFinalized: '3',
   RunoffPending: '4',
   RunoffFinalized: '5',
+  AutomaticallyFinalized: '6',
 };
 
 const SlateStatus = {

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -393,11 +393,9 @@ async function getVotes(gatekeeper, ballotID, categoryID, slateID) {
 const ContestStatus = {
   Empty: '0',
   NoContest: '1',
-  Started: '2',
-  VoteFinalized: '3',
-  RunoffPending: '4',
-  RunoffFinalized: '5',
-  AutomaticallyFinalized: '6',
+  Active: '2',
+  RunoffPending: '3',
+  Finalized: '4',
 };
 
 const SlateStatus = {

--- a/packages/panvala-utils/dist/index.js
+++ b/packages/panvala-utils/dist/index.js
@@ -9,10 +9,9 @@ const SlateCategories = {
 const ContestStatus = {
     Empty: '0',
     NoContest: '1',
-    Started: '2',
-    VoteFinalized: '3',
-    RunoffPending: '4',
-    RunoffFinalized: '5',
+    Active: '2',
+    RunoffPending: '3',
+    Finalized: '4',
 };
 /**
  * generateCommitHash

--- a/packages/panvala-utils/voting/index.ts
+++ b/packages/panvala-utils/voting/index.ts
@@ -14,10 +14,9 @@ const SlateCategories = {
 const ContestStatus = {
   Empty: '0',
   NoContest: '1',
-  Started: '2',
-  VoteFinalized: '3',
-  RunoffPending: '4',
-  RunoffFinalized: '5',
+  Active: '2',
+  RunoffPending: '3',
+  Finalized: '4',
 };
 
 /**


### PR DESCRIPTION
This PR enforces that only staked slates are counted in a contest. If a slate is the only staked slate in a contest, it automatically wins when the contest is finalized.

* Use the current epoch number when creating a slate
* Only include staked slates in voting
  * Only use staked slates to determine the contest status
  * Only count votes for staked slates