### PR TITLE
stake on a slate just created; filter ballot: staked slates

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -23,7 +23,7 @@
     "ethers": "^4.0.26",
     "express": "^4.16.4",
     "express-validator": "^5.3.1",
-    "ipfs-http-client": "^30.1.3",
+    "ipfs-http-client": "32.0.1",
     "lodash": "4.17.11",
     "morgan": "^1.9.1",
     "pg": "^7.8.0",

--- a/api/utils/ipfs.js
+++ b/api/utils/ipfs.js
@@ -13,25 +13,23 @@ const ipfs = new IPFS({ host: ipfsHost, port: ipfsPort, protocol: 'https' });
  * @param {Object} options
  */
 async function get(multihash, options) {
-  const json = options.json || false;
-
-  return new Promise((resolve, reject) => {
-    ipfs.cat(multihash, (err, result) => {
-      if (err) reject(new Error(err));
-      let data;
-      if (json) {
-        try {
-          data = JSON.parse(result);
-        } catch (error) {
-          console.log("error.message:", error.message);
-          reject(new Error(`error while trying to parse result: ${error.message}`));
-        }
-      } else {
-        data = result;
+  try {
+    const result = await ipfs.cat(multihash);
+    console.log('');
+    console.log('result:', result);
+    if (options.json) {
+      try {
+        const data = JSON.parse(result);
+        return data;
+      } catch (error) {
+        console.log(`ERROR: while JSON.parse result: ${error.message}`);
+        throw error;
       }
-      resolve(data);
-    });
-  });
+    }
+  } catch (error) {
+    console.log('ERROR: while retrieving an object from ipfs:', error.message);
+    throw error;
+  }
 }
 
 module.exports = {

--- a/api/utils/slates.js
+++ b/api/utils/slates.js
@@ -1,5 +1,6 @@
 const ethers = require('ethers');
 const ipfs = require('./ipfs');
+const range = require('lodash/range')
 
 const { Slate } = require('../models');
 
@@ -34,7 +35,7 @@ async function getAllSlates() {
   console.log(`fetching ${slateCount} slates`);
 
   // 0..slateCount
-  const ids = Array.from(Array(slateCount.toNumber()).keys());
+  const ids = range(0, slateCount);
   // console.log('IDs', ids);
 
   const slatePromises = ids.map(slateID => {
@@ -97,6 +98,7 @@ async function getSlateWithMetadata(slate, metadataHash, requiredStake) {
       proposalMultihashes,
     } = slateMetadata;
     console.log('proposalMultihashes:', proposalMultihashes);
+    console.log('');
 
     // TODO: rehydrate proposals
 
@@ -128,7 +130,7 @@ async function getSlateWithMetadata(slate, metadataHash, requiredStake) {
     };
     return slateData;
   } catch (error) {
-    console.log('error while combining slate with metadata', error);
+    console.log('ERROR: while combining slate with metadata: ', error.message);
     throw error;
   }
 }

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1010,14 +1010,14 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-cids@~0.5.4, cids@~0.5.5, cids@~0.5.6:
-  version "0.5.8"
-  resolved "https://registry.yarnpkg.com/cids/-/cids-0.5.8.tgz#3d5000c3856a2d3c00967b21265aa57142611aa0"
-  integrity sha512-Ye8TZP3YQfy0j+i5k+LPHdTY3JOvTwN1pxds44p6BRUv8PTMOAF/Vt4Bc+oiIQ0Sktn0iftkUHgqKNHIMwhshA==
+cids@~0.7.0, cids@~0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/cids/-/cids-0.7.1.tgz#d8bba49a35a0e82110879b5001abf1039c62347f"
+  integrity sha512-qEM4j2GKE/BiT6WdUi6cfW8dairhSLTUE8tIdxJG6SvY33Mp/UPjw+xcO0n1zsllgo72BupzKF/44v+Bg8YPPg==
   dependencies:
     class-is "^1.1.0"
     multibase "~0.6.0"
-    multicodec "~0.5.0"
+    multicodec "~0.5.1"
     multihashes "~0.4.14"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
@@ -1159,7 +1159,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@hugomrdias/concat-stream#feat/smaller:
+"concat-stream@github:hugomrdias/concat-stream#feat/smaller":
   version "2.0.0"
   resolved "https://codeload.github.com/hugomrdias/concat-stream/tar.gz/057bc7b5d6d8df26c8cf00a3f151b6721a0a8034"
   dependencies:
@@ -2467,55 +2467,57 @@ ipaddr.js@1.8.0:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
   integrity sha1-6qM9bd16zo9/b+DJygRA5wZzix4=
 
-ipfs-block@~0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/ipfs-block/-/ipfs-block-0.8.0.tgz#1004bcc67dad0413c70fc6d56e86537716debd7d"
-  integrity sha512-znNtFRxXlJYP1/Q4u0tGFJUceH9pNww8WA+zair6T3y7d28m+vtUDJGn96M7ZlFFSkByQyQsAiq2ssNhKtMzxw==
+ipfs-block@~0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/ipfs-block/-/ipfs-block-0.8.1.tgz#05e1068832775e8f1c2da5b64106cc837fd2acb9"
+  integrity sha512-0FaCpmij+jZBoUYhjoB5ptjdl9QzvrdRIoBmUU5JiBnK2GA+4YM/ifklaB8ePRhA/rRzhd+KYBjvMFMAL4NrVQ==
   dependencies:
-    cids "~0.5.5"
+    cids "~0.7.0"
     class-is "^1.1.0"
 
-ipfs-http-client@^30.1.3:
-  version "30.1.3"
-  resolved "https://registry.yarnpkg.com/ipfs-http-client/-/ipfs-http-client-30.1.3.tgz#4767ed544fcaa1ac44d6b39cb2fc85cef170899f"
-  integrity sha512-NQ7WTLKUZeoKaKXrTSLAtjASRYCR0bPdsolZf16Y7Gt7o3RfiPpFF+AqvP0xbekOV3/zhFj2Qyf6ShEV4CCtsQ==
+ipfs-http-client@32.0.1:
+  version "32.0.1"
+  resolved "https://registry.yarnpkg.com/ipfs-http-client/-/ipfs-http-client-32.0.1.tgz#4f5845c56717c748751e70e5d579b7b18af9e824"
+  integrity sha512-uDJjjAg9zvuiAucBE/o0I+xHu9Q9ZoLvj0cTyk+Jf+0duom1iIt2iEEN1HW+PNnZu12zYQWV3sB+tI5TN2lo7A==
   dependencies:
     async "^2.6.1"
     bignumber.js "^8.0.2"
     bl "^3.0.0"
     bs58 "^4.0.1"
     buffer "^5.2.1"
-    cids "~0.5.5"
-    concat-stream hugomrdias/concat-stream#feat/smaller
+    cids "~0.7.1"
+    concat-stream "github:hugomrdias/concat-stream#feat/smaller"
     debug "^4.1.0"
     detect-node "^2.0.4"
     end-of-stream "^1.4.1"
     err-code "^1.1.2"
     flatmap "0.0.3"
     glob "^7.1.3"
-    ipfs-block "~0.8.0"
-    ipld-dag-cbor "~0.13.1"
-    ipld-dag-pb "~0.15.3"
-    is-ipfs "~0.6.0"
+    ipfs-block "~0.8.1"
+    ipfs-utils "~0.0.3"
+    ipld-dag-cbor "~0.15.0"
+    ipld-dag-pb "~0.17.3"
+    is-ipfs "~0.6.1"
     is-pull-stream "0.0.0"
-    is-stream "^1.1.0"
+    is-stream "^2.0.0"
     iso-stream-http "~0.1.2"
     iso-url "~0.4.6"
     just-kebab-case "^1.1.0"
     just-map-keys "^1.1.0"
+    kind-of "^6.0.2"
     lru-cache "^5.1.1"
     multiaddr "^6.0.6"
     multibase "~0.6.0"
-    multicodec "~0.5.0"
+    multicodec "~0.5.1"
     multihashes "~0.4.14"
-    ndjson hugomrdias/ndjson#feat/readable-stream3
+    ndjson "github:hugomrdias/ndjson#feat/readable-stream3"
     once "^1.4.0"
     peer-id "~0.12.2"
     peer-info "~0.15.1"
     promisify-es6 "^1.0.3"
     pull-defer "~0.2.3"
     pull-stream "^3.6.9"
-    pull-to-stream "~0.1.0"
+    pull-to-stream "~0.1.1"
     pump "^3.0.0"
     qs "^6.5.2"
     readable-stream "^3.1.1"
@@ -2523,33 +2525,40 @@ ipfs-http-client@^30.1.3:
     tar-stream "^2.0.1"
     through2 "^3.0.1"
 
-ipld-dag-cbor@~0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/ipld-dag-cbor/-/ipld-dag-cbor-0.13.1.tgz#2ffecba3a13b29d8b604ee3d9b5dad0d4542e26b"
-  integrity sha512-96KKh5XUq9LrWE/TQ/BOJ5FcQx7UZ892N76ufDdovq+fIwZ4/YpPRTAVssLUuN3crATHoGu80TVZMgevsuTCdQ==
+ipfs-utils@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/ipfs-utils/-/ipfs-utils-0.0.3.tgz#b56e0f2294ea627c61af11f1a169370609797226"
+  integrity sha512-x3X8Q7gDPR0Zta/3Zftx2JUP3lNfrWqHgExD6aSLTBcxHKQViaOgKCsGr0SMiMYeyXNCrbI8nKlpusQyusTUrg==
+  dependencies:
+    buffer "^5.2.1"
+    is-buffer "^2.0.3"
+    is-electron "^2.2.0"
+    is-pull-stream "0.0.0"
+    is-stream "^2.0.0"
+    kind-of "^6.0.2"
+    readable-stream "^3.3.0"
+
+ipld-dag-cbor@~0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/ipld-dag-cbor/-/ipld-dag-cbor-0.15.0.tgz#1fbebef1c2d8b980fb18b94f96ec3c1f1d32f860"
+  integrity sha512-wc9nrDtV4Le76UUhG4LXX57NVi5d7JS2kLid2nOYZAcr0SFhiXZL2ZyV3bfmNohO50KvgPEessSaBBSm9bflGA==
   dependencies:
     borc "^2.1.0"
-    bs58 "^4.0.1"
-    cids "~0.5.5"
+    cids "~0.7.0"
     is-circular "^1.0.2"
-    multihashes "~0.4.14"
-    multihashing-async "~0.5.1"
-    traverse "~0.6.6"
+    multicodec "~0.5.0"
+    multihashing-async "~0.7.0"
 
-ipld-dag-pb@~0.15.3:
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/ipld-dag-pb/-/ipld-dag-pb-0.15.3.tgz#0f72b99e77e3265f722457de5dc63b0f700fbb7d"
-  integrity sha512-J1RJzSVCaOpxPmSzXbwVNsAZPHctjY4OjqG1dMIG86Z37CKvuy1QwCFkDhNccUTcQpF3sXfj5e0ZUyMM035vzg==
+ipld-dag-pb@~0.17.3:
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/ipld-dag-pb/-/ipld-dag-pb-0.17.3.tgz#221f11d58c03b99ba232681b10a0d991d5af1a75"
+  integrity sha512-+sQagFr9uCCc3SiwAtSUVwoRlg/JqnsVeXGLLUqJ1Lx1HtbfzCA7M3Kv/iSezoeQ8IS5CHoxUfzzqvj7RNEyLg==
   dependencies:
-    async "^2.6.1"
-    bs58 "^4.0.1"
-    cids "~0.5.4"
+    cids "~0.7.0"
     class-is "^1.1.0"
-    is-ipfs "~0.6.0"
-    multihashing-async "~0.5.1"
+    multicodec "~0.5.1"
+    multihashing-async "~0.7.0"
     protons "^1.0.1"
-    pull-stream "^3.6.9"
-    pull-traverse "^1.0.3"
     stable "~0.1.8"
 
 is-accessor-descriptor@^0.1.6:
@@ -2587,6 +2596,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
+  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
 is-callable@^1.1.4:
   version "1.1.4"
@@ -2654,6 +2668,11 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
+is-electron@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.0.tgz#8943084f09e8b731b3a7a0298a7b5d56f6b7eef0"
+  integrity sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==
+
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -2717,14 +2736,14 @@ is-ip@^2.0.0:
   dependencies:
     ip-regex "^2.0.0"
 
-is-ipfs@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/is-ipfs/-/is-ipfs-0.6.0.tgz#97e80f6fee09381042111721aeaf017a31df0fff"
-  integrity sha512-q/CO69rN+vbw9eGXGQOAa15zXq+pSyhdKvE7mqvuplDu67LyT3H9t3RyYQvKpueN7dL4f6fbyjEMPp9J3rJ4qA==
+is-ipfs@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/is-ipfs/-/is-ipfs-0.6.1.tgz#c85069c73275dc6a60673c791a9be731e2b4bfc4"
+  integrity sha512-WhqQylam6pODS2RyqT/u0PR5KWtBZNCgPjgargFOVQjzw/3+6d0midXenzU65klM4LH13IUiCC6ObhDUdXZ7Nw==
   dependencies:
     bs58 "^4.0.1"
-    cids "~0.5.6"
-    mafmt "^v6.0.7"
+    cids "~0.7.0"
+    mafmt "^6.0.7"
     multiaddr "^6.0.4"
     multibase "~0.6.0"
     multihashes "~0.4.13"
@@ -2820,6 +2839,11 @@ is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
 is-symbol@^1.0.2:
   version "1.0.2"
@@ -3644,7 +3668,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@4.17.11, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5:
+lodash@4.17.11, lodash@^4.17.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -3711,7 +3735,7 @@ lru-queue@0.1:
   dependencies:
     es5-ext "~0.10.2"
 
-mafmt@^6.0.2, mafmt@^v6.0.7:
+mafmt@^6.0.2, mafmt@^6.0.7:
   version "6.0.7"
   resolved "https://registry.yarnpkg.com/mafmt/-/mafmt-6.0.7.tgz#80312e08bfba0f89e2daa403525f33e07d9b97fa"
   integrity sha512-2OG/EGAJZmpZBl7YRT1hD83sZa2gKsUEdegRuURreIOe7B4VeHU1rYYmhgk7BkLzknGL3xGYsDx3bbSgEEzE7g==
@@ -3971,7 +3995,7 @@ multibase@~0.6.0:
   dependencies:
     base-x "3.0.4"
 
-multicodec@~0.5.0:
+multicodec@~0.5.0, multicodec@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-0.5.1.tgz#fa4d6fbb99abdf3cec0f207a022ce20ad3813fd5"
   integrity sha512-Q5glyZLdXVbbBxvRYHLQHpu8ydVf1422Z+v9fU47v2JCkiue7n+JcFS7uRv0cQW8hbVtgdtIDgYWPWaIKEXuXA==
@@ -3996,6 +4020,23 @@ multihashing-async@~0.5.1:
     multihashes "~0.4.13"
     murmurhash3js "^3.0.1"
     nodeify "^1.0.1"
+
+multihashing-async@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/multihashing-async/-/multihashing-async-0.7.0.tgz#3234fb98295be84386b85bfd20377d3e5be20d6b"
+  integrity sha512-SCbfl3f+DzJh+/5piukga9ofIOxwfT05t8R4jfzZIJ88YE9zU9+l3K2X+XB19MYyxqvyK9UJRNWbmQpZqQlbRA==
+  dependencies:
+    blakejs "^1.1.0"
+    buffer "^5.2.1"
+    err-code "^1.1.2"
+    js-sha3 "~0.8.0"
+    multihashes "~0.4.13"
+    murmurhash3js-revisited "^3.0.0"
+
+murmurhash3js-revisited@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz#6bd36e25de8f73394222adc6e41fa3fac08a5869"
+  integrity sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==
 
 murmurhash3js@^3.0.1:
   version "3.0.1"
@@ -4034,7 +4075,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-ndjson@hugomrdias/ndjson#feat/readable-stream3:
+"ndjson@github:hugomrdias/ndjson#feat/readable-stream3":
   version "1.5.0"
   resolved "https://codeload.github.com/hugomrdias/ndjson/tar.gz/4db16da6b42e5b39bf300c3a7cde62abb3fa3a11"
   dependencies:
@@ -4776,17 +4817,12 @@ pull-stream@^3.2.3, pull-stream@^3.6.9:
   resolved "https://registry.yarnpkg.com/pull-stream/-/pull-stream-3.6.9.tgz#c774724cd63bc0984c3695f74c819aa02e977320"
   integrity sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw==
 
-pull-to-stream@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/pull-to-stream/-/pull-to-stream-0.1.0.tgz#2f90800962bbb548f2eb03ecdb4f97c9810b9132"
-  integrity sha512-LMvdE0JwT7XQZMFjc7JDl/G9gmoZ8Zo8e86SG4ZZUcjuwvod803KxpAK8WrmdxzHsMRK9DETlIzuA0tbEVv6jg==
+pull-to-stream@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pull-to-stream/-/pull-to-stream-0.1.1.tgz#fa2058528528e3542b81d6f17cbc42288508ff37"
+  integrity sha512-thZkMv6F9PILt9zdvpI2gxs19mkDrlixYKX6cOBxAW16i1NZH+yLAmF4r8QfJ69zuQh27e01JZP9y27tsH021w==
   dependencies:
     readable-stream "^3.1.1"
-
-pull-traverse@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/pull-traverse/-/pull-traverse-1.0.3.tgz#74fb5d7be7fa6bd7a78e97933e199b7945866938"
-  integrity sha1-dPtde+f6a9enjpeTPhmbeUWGaTg=
 
 pump@^3.0.0:
   version "3.0.0"
@@ -4872,7 +4908,7 @@ read-pkg@^4.0.1:
     parse-json "^4.0.0"
     pify "^3.0.0"
 
-"readable-stream@2 || 3", readable-stream@^3.0.0, readable-stream@^3.0.1, readable-stream@^3.0.2, readable-stream@^3.1.1:
+"readable-stream@2 || 3", readable-stream@^3.0.0, readable-stream@^3.0.1, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.3.0.tgz#cb8011aad002eb717bf040291feba8569c986fb9"
   integrity sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==
@@ -5842,11 +5878,6 @@ tr46@^1.0.1:
   integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
   dependencies:
     punycode "^2.1.0"
-
-traverse@~0.6.6:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
-  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
 
 trim-right@^1.0.1:
   version "1.0.1"

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -3668,7 +3668,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@4.17.11, lodash@^4.17.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5:
+lodash@4.17.11, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==

--- a/client/.storybook/config.js
+++ b/client/.storybook/config.js
@@ -3,6 +3,7 @@ import { configure, addParameters } from '@storybook/react';
 addParameters({
   options: {
     panelPosition: 'right',
+    showPanel: false,
   },
 });
 

--- a/client/components/Checkbox.tsx
+++ b/client/components/Checkbox.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Field } from './FieldText';
 import { COLORS } from '../styles';
 import Label from './Label';
-import { Radio } from '@material-ui/core';
+import { Radio, withStyles } from '@material-ui/core';
 
 // const CheckboxInput = styled.input`
 //   width: 40px;
@@ -19,8 +19,8 @@ const Wrapper = styled.div`
   align-items: center;
 `;
 
-const ToggleLabel = styled(Label)`
-  margin: 1em;
+const ToggleLabel: any = styled(Label)`
+  margin: 0.75rem;
   margin-left: 0;
   font-size: 1em;
   color: ${COLORS.grey2};
@@ -32,22 +32,42 @@ const Checkbox = (props: any) => {
       <Wrapper>
         <Field name={props.name} required>
           {({ field, form }: any) => (
-            <Radio
-              checked={field.value.includes(props.value)}
-              onChange={() => {
-                form.setFieldValue(props.name, props.value);
-              }}
-              value={props.value}
-              color="secondary"
-              name={props.name}
-              aria-label="D"
-            />
+            <>
+              <Radio
+                checked={field.value.includes(props.value)}
+                onChange={() => form.setFieldValue(props.name, props.value)}
+                value={props.value}
+                name={props.name}
+                aria-label="D"
+                classes={{
+                  root: props.classes.radio,
+                  checked: props.classes.checked,
+                }}
+              />
+              <ToggleLabel
+                onClick={() => form.setFieldValue(props.name, props.value)}
+                htmlFor={props.name}
+              >
+                {props.label}
+              </ToggleLabel>
+            </>
           )}
         </Field>
-        <ToggleLabel htmlFor={props.name}>{props.label}</ToggleLabel>
       </Wrapper>
     </>
   );
 };
 
-export default Checkbox;
+const styles = (theme: any) => {
+  return {
+    checked: {},
+    radio: {
+      padding: '0.5rem',
+      color: COLORS.greyBorder,
+      '&$checked': {
+        color: COLORS.primary,
+      },
+    },
+  };
+};
+export default withStyles(styles)(Checkbox);

--- a/client/components/EthereumProvider.tsx
+++ b/client/components/EthereumProvider.tsx
@@ -45,8 +45,10 @@ function reducer(state: any, action: any) {
         ...state,
         ...action.payload,
       };
-    default:
-      throw new Error();
+    default: {
+      console.error('Unknown action type provided to Eth Provider', action);
+      return state;
+    }
   }
 }
 

--- a/client/components/MainProvider.tsx
+++ b/client/components/MainProvider.tsx
@@ -59,12 +59,14 @@ function reducer(state: any, action: any) {
     case 'slates':
       return {
         ...state,
-        slates: action.payload,
+        slates: action.slates,
+        slatesByID: action.slatesByID,
       };
     case 'proposals':
       return {
         ...state,
-        proposals: action.payload,
+        proposals: action.proposals,
+        proposalsByID: action.proposalsByID,
       };
     default:
       throw new Error();
@@ -139,11 +141,13 @@ export default function MainProvider(props: any) {
 
   async function handleRefreshProposals() {
     const proposals: IProposal[] = await handleGetAllProposals();
-    return dispatch({ type: 'proposals', payload: proposals });
+    const proposalsByID = keyBy(proposals, 'id');
+    return dispatch({ type: 'proposals', proposals, proposalsByID });
   }
   async function handleRefreshSlates() {
     const slates: ISlate[] = await handleGetAllSlates();
-    return dispatch({ type: 'slates', payload: slates });
+    const slatesByID = keyBy(slates, 'id');
+    return dispatch({ type: 'slates', slates, slatesByID });
   }
 
   const value: IMainContext = {

--- a/client/components/ProposalForm.tsx
+++ b/client/components/ProposalForm.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as yup from 'yup';
+import styled from 'styled-components';
 import { Formik, Form } from 'formik';
 import { Separator } from '../components/Separator';
 import Label from './Label';
@@ -87,7 +88,7 @@ const ProposalForm: React.SFC<IProps> = ({ onHandleSubmit }) => {
       >
         {({ isSubmitting, setFieldValue }) => (
           <Form>
-            <div className="pa4">
+            <PaddedDiv>
               <SectionLabel>{'PERSONAL INFORMATION'}</SectionLabel>
 
               <FieldText
@@ -99,11 +100,11 @@ const ProposalForm: React.SFC<IProps> = ({ onHandleSubmit }) => {
               <FieldText label={'Last Name'} name="lastName" placeholder="Enter your last name" />
               <FieldText required label={'Email'} name="email" placeholder="Enter your email" />
               <FieldText label={'Github'} name="github" placeholder="Enter your github username" />
-            </div>
+            </PaddedDiv>
 
             <Separator />
 
-            <div className="pa4">
+            <PaddedDiv>
               <SectionLabel>{'PROJECT DETAILS'}</SectionLabel>
 
               <FieldText
@@ -156,11 +157,11 @@ const ProposalForm: React.SFC<IProps> = ({ onHandleSubmit }) => {
                   placeholder="Choose file"
                 />
               </div>
-            </div>
+            </PaddedDiv>
 
             <Separator />
 
-            <div className="pa4">
+            <PaddedDiv>
               <SectionLabel>{'FINANCIAL DETAILS'}</SectionLabel>
 
               <FieldTextarea
@@ -188,25 +189,33 @@ const ProposalForm: React.SFC<IProps> = ({ onHandleSubmit }) => {
                 name="otherFunding"
                 placeholder="Enter any other funding you have received"
               />
-            </div>
+            </PaddedDiv>
 
             <Separator />
 
-            <div className="flex flex-column pv2 ph4 items-end">
-              <div className="flex">
-                <Button type="default" large disabled={true}>
-                  {'Back'}
-                </Button>
-                <Button type="submit" large primary disabled={isSubmitting}>
-                  {'Confirm and Submit'}
-                </Button>
-              </div>
-            </div>
+            <FormActions>
+              <Button type="default" large disabled={true}>
+                {'Back'}
+              </Button>
+              <Button type="submit" large primary disabled={isSubmitting}>
+                {'Confirm and Submit'}
+              </Button>
+            </FormActions>
           </Form>
         )}
       </Formik>
     </div>
   );
 };
+
+const PaddedDiv = styled.div`
+  padding: 2rem;
+`;
+
+const FormActions = styled.div`
+  display: flex;
+  padding: 2rem;
+  justify-content: flex-end;
+`;
 
 export default ProposalForm;

--- a/client/components/Stepper.tsx
+++ b/client/components/Stepper.tsx
@@ -61,7 +61,7 @@ interface IProps {
   handleClose?(): void;
   handleClick?(): any;
   handleCancel?(): any;
-  step: number;
+  currentStep: number;
   steps: any[];
 }
 const Stepper: React.SFC<IProps> = props => {
@@ -71,9 +71,11 @@ const Stepper: React.SFC<IProps> = props => {
         <Wrapper>
           <Overlay onClick={props.handleCancel} className="Stepper-overlay" />
           <StepperBody {...props}>
-            <StepperTitle>{`Step ${props.step || 1} of ${props.steps.length}`}</StepperTitle>
+            <StepperTitle>{`Step ${props.currentStep + 1 || 1} of ${
+              props.steps.length
+            }`}</StepperTitle>
             <CancelButton onClick={props.handleCancel}>Cancel</CancelButton>
-            {props.children}
+            {props.steps[props.currentStep]}
           </StepperBody>
         </Wrapper>
       )}

--- a/client/components/stories/CreateProposal.stories.tsx
+++ b/client/components/stories/CreateProposal.stories.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import CreateProposal from '../../pages/proposals/create';
+import MainProvider from '../MainProvider';
+import Layout from '../Layout';
+
+storiesOf('Create a Proposal', module).add('ProposalForm', () => {
+  console.log('fdf');
+  return (
+    <MainProvider>
+      <Layout>
+        <CreateProposal />
+      </Layout>
+    </MainProvider>
+  );
+});

--- a/client/components/stories/CreateSlate.stories.tsx
+++ b/client/components/stories/CreateSlate.stories.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import CreateSlate from '../../pages/slates/create';
+import MainProvider from '../MainProvider';
+import Layout from '../Layout';
+import EthereumProvider from '../EthereumProvider';
+import NotificationsProvider from '../NotificationsProvider';
+
+storiesOf('Create Slate', module).add('Stake immediately', () => {
+  return (
+    <EthereumProvider>
+      <MainProvider>
+        <NotificationsProvider>
+          <Layout>
+            <CreateSlate query={{ id: '0' }} />
+          </Layout>
+        </NotificationsProvider>
+      </MainProvider>
+    </EthereumProvider>
+  );
+});

--- a/client/components/stories/Stepper.stories.tsx
+++ b/client/components/stories/Stepper.stories.tsx
@@ -13,7 +13,7 @@ const StepperDialog = styled.div`
   line-height: 2rem;
 `;
 
-const requiredStake = '400';
+const requiredStake = '5000.0 PAN';
 
 const stories = storiesOf('Stepper Knobs', module);
 stories.addDecorator(withKnobs);
@@ -24,8 +24,25 @@ stories.add('Step 1/2: sign message', () => {
     'Text',
     'To prove you are the account owner, please sign this message. This is similar to signing in with a password.'
   );
+  const steps = [
+    <div>
+      <StepperDialog>
+        {`By confirming this transaction, you approve to spend ${requiredStake} tokens to stake for this slate.`}
+      </StepperDialog>
+      <StepperMetamaskDialog />
+      <MetamaskButton handleClick={() => null} text={`Approve ${requiredStake}`} />
+    </div>,
+    <div>
+      <StepperDialog>
+        {`By confirming this transaction, you are spending ${requiredStake} tokens to stake for this slate.`}
+      </StepperDialog>
+      <StepperMetamaskDialog />
+      <MetamaskButton handleClick={() => null} text={`Stake ${requiredStake}`} />
+    </div>,
+  ];
+
   return (
-    <Stepper isOpen={isOpen} steps={2} handleCancel={action('button-cancel')}>
+    <Stepper isOpen={isOpen} steps={steps} currentStep={1} handleCancel={action('button-cancel')}>
       <StepperDialog>{dialogText}</StepperDialog>
       <StepperMetamaskDialog />
 
@@ -35,17 +52,17 @@ stories.add('Step 1/2: sign message', () => {
   );
 });
 
-stories.add(`Step 2/2: approve ${requiredStake} pan`, () => {
+stories.add(`Step 2/2: approve ${requiredStake}`, () => {
   return (
-    <Stepper isOpen={true} step={2} steps={2} handleCancel={action('button-cancel')}>
+    <Stepper isOpen={true} currentStep={2} steps={[1, 2]} handleCancel={action('button-cancel')}>
       <StepperDialog>
         Waiting to confirm in MetaMask. By confirming this transaction, you approve to spend{' '}
-        {requiredStake} PAN tokens to stake for this slate.
+        {requiredStake} tokens to stake for this slate.
       </StepperDialog>
       <StepperMetamaskDialog />
 
       <Image src="/static/signature-request-tip.svg" alt="signature request tip" wide />
-      <MetamaskButton handleClick={action('button-click')} text={`Approve ${requiredStake} PAN`} />
+      <MetamaskButton handleClick={action('button-click')} text={`Approve ${requiredStake}`} />
     </Stepper>
   );
 });
@@ -54,7 +71,7 @@ stories.add('Step 2/2: approve all tokens', () => {
   const numTokens = 6789;
   const step = 2;
   return (
-    <Stepper isOpen={true} step={step} steps={2} handleCancel={action('button-cancel')}>
+    <Stepper isOpen={true} currentStep={step} steps={[1, 2]} handleCancel={action('button-cancel')}>
       <StepperDialog>
         Waiting to confirm in MetaMask. By confirming this transaction, you approve to vote with all
         your PAN tokens. You will not lose or gain any tokens regardless of outcome.
@@ -62,7 +79,7 @@ stories.add('Step 2/2: approve all tokens', () => {
       <StepperMetamaskDialog />
 
       <Image src="/static/signature-request-tip.svg" alt="signature request tip" wide />
-      <MetamaskButton handleClick={action('button-click')} text={`Approve ${numTokens} PAN`} />
+      <MetamaskButton handleClick={action('button-click')} text={`Approve ${requiredStake}`} />
     </Stepper>
   );
 });

--- a/client/pages/ballots/vote.tsx
+++ b/client/pages/ballots/vote.tsx
@@ -20,7 +20,7 @@ import { ISlate, IMainContext, IEthereumContext, ISubmitBallot, IChoices } from 
 import { randomSalt, generateCommitHash, generateCommitMessage } from '../../utils/voting';
 import { baseToConvertedUnits } from '../../utils/format';
 import { postBallot } from '../../utils/api';
-import { convertEVMSlateStatus } from '../../utils/status';
+import { convertEVMSlateStatus, SlateStatus } from '../../utils/status';
 import Actions from '../../components/Actions';
 
 type IProps = {
@@ -44,8 +44,6 @@ const Vote: React.FunctionComponent<IProps> = ({ router }) => {
     votingRights,
     ethProvider,
   }: IEthereumContext = React.useContext(EthereumContext);
-
-  console.log('slates:', slates);
 
   // component state
   // choice selector
@@ -223,22 +221,24 @@ const Vote: React.FunctionComponent<IProps> = ({ router }) => {
           <Label required>{'Select your first and second choice slate'}</Label>
           <div className="flex flex-wrap mt3">
             {slates && slates.length > 0
-              ? slates.map((slate: ISlate) => (
-                  <Card
-                    key={slate.id}
-                    title={slate.title}
-                    subtitle={slate.proposals.length + ' Grants Included'}
-                    description={slate.description}
-                    category={slate.category}
-                    status={convertEVMSlateStatus(slate.status)}
-                    choices={choices}
-                    address={slate.recommenderAddress}
-                    onSetChoice={handleSetChoice}
-                    proposals={slate.proposals}
-                    slateID={slate.id.toString()}
-                    asPath={'/ballots/vote'}
-                  />
-                ))
+              ? slates
+                  .filter(s => s.status === SlateStatus.Staked)
+                  .map((slate: ISlate) => (
+                    <Card
+                      key={slate.id}
+                      title={slate.title}
+                      subtitle={slate.proposals.length + ' Grants Included'}
+                      description={slate.description}
+                      category={slate.category}
+                      status={convertEVMSlateStatus(slate.status)}
+                      choices={choices}
+                      address={slate.recommenderAddress}
+                      onSetChoice={handleSetChoice}
+                      proposals={slate.proposals}
+                      slateID={slate.id.toString()}
+                      asPath={'/ballots/vote'}
+                    />
+                  ))
               : null}
           </div>
         </div>

--- a/client/pages/proposals/proposal.tsx
+++ b/client/pages/proposals/proposal.tsx
@@ -199,6 +199,7 @@ const Proposal: StatelessPage<IProps> = ({ query: { id } }) => {
 const FlexColumn = styled.div`
   display: flex;
   flex-direction: column;
+  font-family: 'Roboto';
 `;
 const HeaderWrapper = styled.div`
   display: flex;

--- a/client/pages/slates/create.tsx
+++ b/client/pages/slates/create.tsx
@@ -309,6 +309,33 @@ const CreateSlate: StatelessPage<IProps> = ({ query, classes }) => {
     // TODO: Should take us to all slates view after successful submission
   }
 
+  const initialValues =
+    process.env.NODE_ENV === 'development'
+      ? {
+          email: 'email@email.com',
+          firstName: 'Guy',
+          lastName: 'Reid',
+          organization: 'Panvala',
+          title: 'Test Slate',
+          description: 'Only the best proposals',
+          recommendation: query && query.id ? 'grant' : '',
+          proposals: query && query.id ? { [query.id.toString()]: true } : {},
+          selectedProposals: [],
+          stake: 'no',
+        }
+      : {
+          email: '',
+          firstName: '',
+          lastName: '',
+          organization: '',
+          title: '',
+          description: '',
+          recommendation: query && query.id ? 'grant' : '',
+          proposals: query && query.id ? { [query.id.toString()]: true } : {},
+          selectedProposals: [],
+          stake: 'no',
+        };
+
   return (
     <div>
       <Modal handleClick={() => setOpenModal(false)} isOpen={txPending || isOpen}>
@@ -341,18 +368,7 @@ const CreateSlate: StatelessPage<IProps> = ({ query, classes }) => {
       <CenteredTitle title="Create a Grant Slate" />
       <CenteredWrapper>
         <Formik
-          initialValues={{
-            email: 'email@email.com',
-            firstName: 'Guy',
-            lastName: 'Reid',
-            organization: 'Panvala',
-            title: 'Test Slate',
-            description: 'Only the best proposals',
-            recommendation: query && query.id ? 'grant' : '',
-            proposals: query && query.id ? { [query.id.toString()]: true } : {},
-            selectedProposals: [],
-            stake: 'no',
-          }}
+          initialValues={initialValues}
           validationSchema={FormSchema}
           onSubmit={async (values: IFormValues, { setSubmitting, setFieldError }: any) => {
             const emptySlate = values.recommendation === 'noAction';

--- a/client/pages/slates/index.tsx
+++ b/client/pages/slates/index.tsx
@@ -69,7 +69,7 @@ const Slates: React.FunctionComponent<Props> = props => {
                   <Card
                     key={slate.id}
                     title={slate.title}
-                    subtitle={slate.proposals.length + ' Grants Included'}
+                    subtitle={slate.proposals && slate.proposals.length + ' Grants Included'}
                     description={slate.description}
                     category={slate.category}
                     status={convertEVMSlateStatus(slate.status)}

--- a/client/pages/slates/slate.tsx
+++ b/client/pages/slates/slate.tsx
@@ -5,7 +5,6 @@ import { COLORS } from '../../styles';
 import Button from '../../components/Button';
 import Card, { CardAddress } from '../../components/Card';
 import Deadline from '../../components/Deadline';
-import { EthereumContext } from '../../components/EthereumProvider';
 import { MainContext } from '../../components/MainProvider';
 import RouterLink from '../../components/RouterLink';
 import RouteTitle from '../../components/RouteTitle';

--- a/client/pages/slates/slate.tsx
+++ b/client/pages/slates/slate.tsx
@@ -12,14 +12,7 @@ import RouteTitle from '../../components/RouteTitle';
 import SectionLabel from '../../components/SectionLabel';
 import Tag from '../../components/Tag';
 import { splitAddressHumanReadable, formatPanvalaUnits } from '../../utils/format';
-import {
-  StatelessPage,
-  IMainContext,
-  ISlate,
-  IBallotDates,
-  IProposal,
-  IEthereumContext,
-} from '../../interfaces';
+import { StatelessPage, IMainContext, ISlate, IBallotDates, IProposal } from '../../interfaces';
 import { convertEVMSlateStatus, statuses } from '../../utils/status';
 
 const Incumbent = styled.div`
@@ -233,6 +226,7 @@ const Slate: StatelessPage<IProps> = ({ query: { id } }) => {
 const FlexColumn = styled.div`
   display: flex;
   flex-direction: column;
+  font-family: 'Roboto';
 `;
 const HeaderWrapper = styled.div`
   display: flex;

--- a/client/pages/slates/stake.tsx
+++ b/client/pages/slates/stake.tsx
@@ -204,11 +204,9 @@ const Stake: StatelessPage<any> = ({ query, classes }) => {
               A deposit of <strong>{`${requiredPAN}`}</strong> tokens is required.
             </SectionStatement>
             <P>
-              {`After a slate has tokens staked, the Panvala token holding community will have the
+              After a slate has tokens staked, the Panvala token holding community will have the
               ability to vote for or against the slate when the voting period begins. If the slate
-              that you stake tokens on is successful, you will receive a supporter reward of
-              ${requiredPAN}. If the slate that you stake tokens on is unsuccessful, you will lose your token
-              deposit.`}
+              that you stake tokens on is unsuccessful, you will lose your token deposit.
             </P>
 
             <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '5rem' }}>

--- a/client/pages/slates/stake.tsx
+++ b/client/pages/slates/stake.tsx
@@ -167,7 +167,7 @@ const Stake: StatelessPage<any> = ({ query, classes }) => {
         handleCancel={() => toggleOpenStepper(false)}
       />
 
-      <Modal handleClick={() => setTxPending(false)} isOpen={txPending || modalIsOpen}>
+      <Modal handleClick={() => setOpenModal(false)} isOpen={txPending || modalIsOpen}>
         {txPending ? (
           <>
             <Image src="/static/metamask-fox.svg" alt="metamask logo" />

--- a/client/pages/slates/stake.tsx
+++ b/client/pages/slates/stake.tsx
@@ -55,6 +55,7 @@ const Stake: StatelessPage<any> = ({ query, classes }) => {
 
   // stepper/modal opener
   const [stepperIsOpen, toggleOpenStepper] = React.useState(false);
+  const [modalIsOpen, setOpenModal] = React.useState(false);
   // pending tx loader
   const [txPending, setTxPending] = React.useState(false);
   const [staked, setStaked] = React.useState(false);
@@ -131,6 +132,7 @@ const Stake: StatelessPage<any> = ({ query, classes }) => {
       onRefreshBalances();
       onRefreshSlates();
       toggleOpenStepper(false);
+      setOpenModal(true);
     }
   }
 
@@ -165,7 +167,7 @@ const Stake: StatelessPage<any> = ({ query, classes }) => {
         handleCancel={() => toggleOpenStepper(false)}
       />
 
-      <Modal handleClick={() => setTxPending(false)} isOpen={txPending || staked}>
+      <Modal handleClick={() => setTxPending(false)} isOpen={txPending || modalIsOpen}>
         {txPending ? (
           <>
             <Image src="/static/metamask-fox.svg" alt="metamask logo" />
@@ -184,7 +186,7 @@ const Stake: StatelessPage<any> = ({ query, classes }) => {
               Now that you have staked tokens on this slate the Panvala token holding community will
               have the ability to vote for or against the slate when the voting period begins.
             </ModalDescription>
-            <Button type="default" onClick={() => setTxPending(false)}>
+            <Button type="default" onClick={() => setOpenModal(false)}>
               {'Done'}
             </Button>
           </>

--- a/client/types/TokenCapacitor.d.ts
+++ b/client/types/TokenCapacitor.d.ts
@@ -31,7 +31,7 @@ export class TokenCapacitor extends Contract {
     createManyProposals(
       beneficiaries: (string)[],
       tokenAmounts: (number | string | BigNumber)[],
-      metadataHashes: ((string)[])[],
+      metadataHashes: (Buffer)[],
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 

--- a/client/utils/transaction.ts
+++ b/client/utils/transaction.ts
@@ -1,10 +1,39 @@
 import { TransactionReceipt, TransactionResponse, Web3Provider } from 'ethers/providers';
 import { LogDescription } from 'ethers/utils';
-import { Contract } from 'ethers';
+import { Contract, utils } from 'ethers';
+import { BasicToken, Gatekeeper, TokenCapacitor } from '../types';
 
 export interface IMinedTransaction {
   receipt: TransactionReceipt;
   decodedLogs?: LogDescription[];
+}
+
+export async function sendApproveTransaction(
+  token: BasicToken,
+  address: string,
+  numTokens: utils.BigNumberish
+): Promise<TransactionResponse> {
+  return token.functions.approve(address, numTokens.toString());
+}
+
+export async function sendStakeTokensTransaction(
+  gatekeeper: Gatekeeper,
+  slateID: number
+): Promise<TransactionResponse> {
+  return gatekeeper.functions.stakeTokens(slateID);
+}
+
+export async function sendCreateManyProposalsTransaction(
+  tokenCapacitor: TokenCapacitor,
+  beneficiaries: string[],
+  tokenAmounts: string[],
+  proposalMultihashes: Buffer[]
+): Promise<TransactionResponse> {
+  return tokenCapacitor.functions.createManyProposals(
+    beneficiaries,
+    tokenAmounts,
+    proposalMultihashes
+  );
 }
 
 /**


### PR DESCRIPTION
this pr adds support for optionally staking on a slate immediately after saving it to the db. there's also a filter now on ballots to only display slates that have been staked.

misc:
- improve readability
- fix stepper component and logic for loading while tx is pending
- ref: `useState` -> `useReducer` in `EthereumProvider`