### PR TITLE
Extend staking deadline when a slate is staked

### DIFF
--- a/client/__tests__/utils/status.test.ts
+++ b/client/__tests__/utils/status.test.ts
@@ -1,4 +1,4 @@
-import { convertEVMSlateStatus } from '../../utils/status';
+import { convertEVMSlateStatus, slateSubmissionDeadline } from '../../utils/status';
 
 describe('Status', () => {
   test('should return the correct status for each EVM slate status', () => {
@@ -15,5 +15,46 @@ describe('Status', () => {
   test('should throw an error if given an invalid status', () => {
     const invalid = convertEVMSlateStatus(7483921);
     expect(invalid).toBe(undefined);
+  });
+
+  describe('slate submission', () => {
+    const oneWeekSeconds: number = 604800;
+    const epochStart = 1549040400; // 2/1
+    const votingOpen = epochStart + oneWeekSeconds * 11;
+
+    test('should calculate the slate submission deadline', () => {
+      const deadline = slateSubmissionDeadline(votingOpen, epochStart);
+      const dt = new Date(deadline * 1000);
+
+      // expect 2019-03-12 00:00
+      expect(dt.getFullYear()).toBe(2019);
+      expect(dt.getMonth()).toBe(2); // March = 2
+      expect(dt.getDate()).toBe(12);
+    });
+
+    test('staked 1 week in', () => {
+      // stake 1 week in
+      const lastStaked = epochStart + oneWeekSeconds;
+      const deadline = slateSubmissionDeadline(votingOpen, lastStaked);
+      const dt = new Date(deadline * 1000);
+
+      // expect 6 weeks in
+      // expect 2019-03-15 12:00
+      expect(dt.getFullYear()).toBe(2019);
+      expect(dt.getMonth()).toBe(2); // March = 2
+      expect(dt.getDate()).toBe(15);
+    });
+
+    test('staked 5 weeks in', () => {
+      const lastStaked = epochStart + oneWeekSeconds * 5;
+      const deadline = slateSubmissionDeadline(votingOpen, lastStaked);
+      const dt = new Date(deadline * 1000);
+
+      // expect 8 weeks in
+      // expect 2019-03-29 12:00
+      expect(dt.getFullYear()).toBe(2019);
+      expect(dt.getMonth()).toBe(2); // March = 2
+      expect(dt.getDate()).toBe(29);
+    });
   });
 });

--- a/client/components/MainProvider.tsx
+++ b/client/components/MainProvider.tsx
@@ -6,6 +6,8 @@ import keyBy from 'lodash/keyBy';
 import { IProposal, ISlate, IMainContext } from '../interfaces';
 import { getAllProposals, getAllSlates } from '../utils/api';
 import { baseToConvertedUnits } from '../utils/format';
+import { slateSubmissionDeadline } from '../utils/status';
+
 
 export const MainContext: React.Context<IMainContext> = React.createContext<IMainContext>({
   slates: [],
@@ -17,6 +19,8 @@ export const MainContext: React.Context<IMainContext> = React.createContext<IMai
     votingOpenDate: 0,
     votingCloseDate: 0,
     finalityDate: 0,
+    initialSlateSubmissionDeadline: 0,
+    slateSubmissionDeadline: {},
   },
 });
 
@@ -120,11 +124,14 @@ export default function MainProvider(props: any) {
       const week12EndDate: number = week11EndDate + oneWeekSeconds;
       // end of week 13 (5/3)
       const week13EndDate: number = week12EndDate + oneWeekSeconds;
+      const initialSlateSubmissionDeadline: number = slateSubmissionDeadline(week11EndDate, epochStartDate);
       const currentBallot = {
         startDate: epochStartDate,
         votingOpenDate: week11EndDate,
         votingCloseDate: week12EndDate,
         finalityDate: week13EndDate,
+        initialSlateSubmissionDeadline,
+        slateSubmissionDeadline: {},
       };
 
       dispatch({

--- a/client/components/stories/Slate.stories.tsx
+++ b/client/components/stories/Slate.stories.tsx
@@ -48,18 +48,35 @@ const rejectedSlate: ISlate = {
 
 const requiredStake = convertedToBaseUnits('5000', 18);
 
+
 storiesOf('SlateHeader', module)
   .add('unstaked', () => <SlateHeader slate={unstakedSlate} currentBallot={currentBallot} />)
   .add('staked', () => <SlateHeader slate={stakedSlate} currentBallot={currentBallot} />);
 
 storiesOf('SlateSidebar', module)
-  .add('unstaked', () => <SlateSidebar slate={unstakedSlate} requiredStake={requiredStake} />)
-  .add('unstaked verified', () => (
-    <SlateSidebar slate={unstakedVerified} requiredStake={requiredStake} />
+  .add('unstaked', () => (
+    <SlateSidebar
+      slate={unstakedSlate}
+      requiredStake={requiredStake}
+      currentBallot={currentBallot}
+    />
   ))
-  .add('staked', () => <SlateSidebar slate={stakedSlate} requiredStake={requiredStake} />)
+  .add('unstaked verified', () => (
+    <SlateSidebar
+      slate={unstakedVerified}
+      requiredStake={requiredStake}
+      currentBallot={currentBallot}
+    />
+  ))
+  .add('staked', () => (
+    <SlateSidebar slate={stakedSlate} requiredStake={requiredStake} currentBallot={currentBallot} />
+  ))
   .add('staked verified', () => (
-    <SlateSidebar slate={stakedVerified} requiredStake={requiredStake} />
+    <SlateSidebar
+      slate={stakedVerified}
+      requiredStake={requiredStake}
+      currentBallot={currentBallot}
+    />
   ));
 
 storiesOf('Slate with contexts', module)

--- a/client/components/stories/data.tsx
+++ b/client/components/stories/data.tsx
@@ -11,7 +11,7 @@ import '../../globalStyles.css';
 };
 
 export const epochStartDate = 1549040401;
-export const currentBallot = ballotDates(15499990);
+export const currentBallot = ballotDates(epochStartDate);
 
 export const proposals: IProposal[] = [
   {

--- a/client/interfaces/contexts.ts
+++ b/client/interfaces/contexts.ts
@@ -110,6 +110,11 @@ export interface IBallotDates {
   votingOpenDate: number;
   votingCloseDate: number;
   finalityDate: number;
+  initialSlateSubmissionDeadline: number;
+  // category -> timestamp
+  slateSubmissionDeadline: {
+    [key: string]: number;
+  };
 }
 
 export interface IContracts {

--- a/client/pages/slates/stake.tsx
+++ b/client/pages/slates/stake.tsx
@@ -131,6 +131,7 @@ const Stake: StatelessPage<any> = ({ query, classes }) => {
       // refresh balances, refresh slates
       onRefreshBalances();
       onRefreshSlates();
+      // TODO: refresh slate submission deadline on ballot
       toggleOpenStepper(false);
       setOpenModal(true);
     }

--- a/client/utils/datetime.ts
+++ b/client/utils/datetime.ts
@@ -19,6 +19,10 @@ export const tsToDeadline = (unixTimestamp: number, customTimezone?: string): st
 
 export const dateHasPassed = (uts: number) => isAfter(new Date(), new Date(uts * 1000));
 
+export const timestamp = (): number => {
+  return Math.floor((new Date()).getTime() / 1000);
+};
+
 // export const formatHtmlDatetime = date => format(date, 'YYYY-MM-DDTHH:mm:ss.SSSZ');
 // export const getEndDateString = uts => format(new Date(uts * 1000), 'MM/DD/YY_HH:mm:ss');
 // export const tsToMonthDate = uts => format(new Date(uts * 1000), 'MMMM Do');

--- a/client/utils/status.ts
+++ b/client/utils/status.ts
@@ -91,11 +91,11 @@ export function getPrefixAndDeadline(
 }
 
 /**
- * Calculate the next slate submission deadline as halfway between now and the close of the
+ * Calculate the next slate submission deadline as halfway between now and the start of the
  * commit period.
  */
-export function slateSubmissionDeadline(votingCloseDate: number, lastStaked: number) {
-  return lastStaked + (votingCloseDate - lastStaked) / 2;
+export function slateSubmissionDeadline(votingOpenDate: number, lastStaked: number) {
+  return lastStaked + (votingOpenDate - lastStaked) / 2;
 }
 
 export function ballotDates(startDate: number): IBallotDates {

--- a/client/utils/status.ts
+++ b/client/utils/status.ts
@@ -90,18 +90,29 @@ export function getPrefixAndDeadline(
   return { deadline, prefix };
 }
 
+/**
+ * Calculate the next slate submission deadline as halfway between now and the close of the
+ * commit period.
+ */
+export function slateSubmissionDeadline(votingCloseDate: number, lastStaked: number) {
+  return lastStaked + (votingCloseDate - lastStaked) / 2;
+}
+
 export function ballotDates(startDate: number): IBallotDates {
   const oneWeekSeconds = 604800;
   const epochStartDate = startDate;
   const week11EndDate = epochStartDate + oneWeekSeconds * 11;
   const week12EndDate = week11EndDate + oneWeekSeconds;
   const week13EndDate = week12EndDate + oneWeekSeconds;
+  const initialSlateSubmissionDeadline = slateSubmissionDeadline(week11EndDate, startDate);
 
   return {
     startDate,
     votingOpenDate: week11EndDate,
     votingCloseDate: week12EndDate,
     finalityDate: week13EndDate,
+    initialSlateSubmissionDeadline,
+    slateSubmissionDeadline: {},
   };
 }
 

--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -174,12 +174,11 @@ contract Gatekeeper {
     /**
     * @dev Get the number of the current epoch.
     */
-    function currentEpochNumber() public pure returns(uint) {
-        // uint elapsed = now.sub(startTime);
-        // uint epoch = elapsed.div(epochLength);
+    function currentEpochNumber() public view returns(uint) {
+        uint elapsed = now.sub(startTime);
+        uint epoch = elapsed.div(epochLength);
 
-        // return epoch;
-        return 0;
+        return epoch;
     }
 
     /**

--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -154,6 +154,9 @@ contract Gatekeeper {
     // epoch number -> Ballot
     mapping(uint => Ballot) public ballots;
 
+    // TEMP allow the contract creator to time travel
+    address owner;
+    int256 timeOffset;
 
     // IMPLEMENTATION
     /**
@@ -162,6 +165,8 @@ contract Gatekeeper {
      @param _parameters The parameter store to use
     */
     constructor(uint _startTime, ParameterStore _parameters) public {
+        owner = msg.sender; // TEMP
+
         parameters = _parameters;
 
         address tokenAddress = parameters.getAsAddress("tokenAddress");
@@ -190,6 +195,24 @@ contract Gatekeeper {
     }
 
 
+    // TEMP ADMIN
+    event TimeTraveled(int256 amount, uint256 startTime);
+
+    /**
+    * @dev Move forward or backward in the epoch by adjusting the start time. Positive numbers move
+    * into the future, while negative numbers move into the past. Only the owner can call this.
+    * @param amount The number of seconds to shift by
+     */
+    function timeTravel(int256 amount) public {
+        require(msg.sender == owner, "Only the owner");
+
+        if (amount > 0) {
+            startTime = startTime.sub(uint256(amount));
+        } else {
+            startTime = startTime.add(uint256(-amount));
+        }
+        emit TimeTraveled(amount, startTime);
+    }
 
     // SLATE GOVERNANCE
     /**

--- a/governance-contracts/package.json
+++ b/governance-contracts/package.json
@@ -29,6 +29,7 @@
         "bs58": "4.0.1",
         "ethereumjs-util": "6.1.0",
         "ethers": "4.0.27",
+        "moment": "^2.24.0",
         "openzeppelin-solidity": "2.1.3",
         "truffle-hdwallet-provider": "1.0.9"
     }

--- a/governance-contracts/test/tokenCapacitor.js
+++ b/governance-contracts/test/tokenCapacitor.js
@@ -227,7 +227,7 @@ contract('TokenCapacitor', (accounts) => {
 
     const initialTokens = '100000000';
     const capacitorSupply = '50000000';
-    const ballotID = 0;
+    let ballotID;
 
     let proposals1;
     let proposals2;
@@ -237,6 +237,7 @@ contract('TokenCapacitor', (accounts) => {
 
     beforeEach(async () => {
       ({ gatekeeper, token, capacitor } = await utils.newPanvala({ initialTokens, from: creator }));
+      ballotID = await gatekeeper.currentEpochNumber();
 
       // Charge the capacitor
       await token.transfer(capacitor.address, capacitorSupply, { from: creator });

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -253,12 +253,12 @@ async function newPanvala(options) {
  * @param {Gatekeeper} gatekeeper
  * @param {*} dt
  */
-async function epochTime(gatekeeper, dt) {
+async function epochTime(gatekeeper, dt, units) {
   const start = await gatekeeper.currentEpochStart();
   const s = moment(start.toString(), 'X');
   const now = moment(dt.toString(), 'X');
   const elapsed = moment.duration(now.diff(s));
-  return elapsed.as('weeks');
+  return elapsed.as(units || 'weeks');
 }
 
 /**

--- a/governance-contracts/truffle-config.js
+++ b/governance-contracts/truffle-config.js
@@ -136,13 +136,13 @@ module.exports = {
     solc: {
       version: '0.5.1',    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
-      // settings: {          // See the solidity docs for advice about optimization and evmVersion
-      //  optimizer: {
-      //    enabled: false,
-      //    runs: 200
-      //  },
+      settings: {          // See the solidity docs for advice about optimization and evmVersion
+        optimizer: {
+          enabled: true,
+          runs: 200,
+        },
       //  evmVersion: "byzantium"
-      // }
+      },
     },
   },
 };

--- a/governance-contracts/yarn.lock
+++ b/governance-contracts/yarn.lock
@@ -2544,6 +2544,11 @@ mock-fs@^4.1.0:
   resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.9.0.tgz#7fc0c2f82965050b2776f8eb4eb63ca53a92ff86"
   integrity sha512-aUj0qIniTNxzGqAC61Bvro7YD37tIBnMw3wpClucUVgNBS7r6YQn/M4wuoH7SGteKz4SvC1OBeDsfpG0MYC+1Q==
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 mout@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/mout/-/mout-0.11.1.tgz#ba3611df5f0e5b1ffbfd01166b8f02d1f5fa2b99"


### PR DESCRIPTION
This contains contract work to extend the staking deadline when a slate is staked, so that other people have time to evaluate it and submit their own slates. It also displays the approximate projected new deadline that would be set after the user stakes, in the slate detail view for unstaked slates.

* Extend the slate submission deadline when a slate is staked
* Implement calculation of epoch numbers
* Enforce the slate submission period for recommending and staking slates
* Temporarily give the Gatekeeper an owner (the creator) who can shift our location in the timeline by adjusting the start time
* Show projected staking deadline in slate sidebar

It does not refresh the local state of deadlines after staking; this will need to happen in future work.
