### PR TITLE
Create slates of governance proposals

### DIFF
--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -258,7 +258,8 @@ contract Gatekeeper {
             uint requestID = requestIDs[i];
             require(requestID < requestCount, "Invalid requestID");
 
-            // TODO: request's resource must match the one passed in
+            // Every request's resource must match the one passed in
+            require(requests[requestID].resource == resource, "Resource does not match");
 
             require(slates[slateID].requestIncluded[requestID] == false, "Duplicate requests are not allowed");
             slates[slateID].requestIncluded[requestID] = true;

--- a/governance-contracts/test/parameterStore.js
+++ b/governance-contracts/test/parameterStore.js
@@ -4,10 +4,9 @@ const utils = require('./utils');
 
 const {
   abiCoder, abiEncode, expectErrorLike, expectRevert, governanceSlateFromProposals,
-  voteSingle, timing, revealVote, BN,
+  voteSingle, timing, revealVote, BN, getResource,
 } = utils;
 
-const { GOVERNANCE } = utils.categories;
 const { increaseTime } = utils.evm;
 
 const ParameterStore = artifacts.require('ParameterStore');
@@ -304,6 +303,7 @@ contract('ParameterStore', (accounts) => {
       }));
 
       ballotID = await gatekeeper.currentEpochNumber();
+      const GOVERNANCE = await getResource(gatekeeper, 'GOVERNANCE');
 
       // Allocate tokens
       const allocatedTokens = '10000';

--- a/governance-contracts/test/tokenCapacitor.js
+++ b/governance-contracts/test/tokenCapacitor.js
@@ -16,7 +16,6 @@ const {
   abiCoder,
   timing,
 } = utils;
-const { GRANT } = utils.categories;
 
 const { increaseTime } = utils.evm;
 
@@ -250,6 +249,7 @@ contract('TokenCapacitor', (accounts) => {
 
       ({ gatekeeper, token, capacitor } = await utils.newPanvala({ initialTokens, from: creator }));
       ballotID = await gatekeeper.currentEpochNumber();
+      const GRANT = await utils.getResource(gatekeeper, 'GRANT');
 
       // Charge the capacitor
       await token.transfer(capacitor.address, capacitorSupply, { from: creator });

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -375,43 +375,6 @@ async function governanceSlateFromProposals(options) {
 }
 
 /**
- * Ask the Gatekeeper for permission and get back the requestIDs
- * @param {*} gatekeeper
- * @param {*} proposalData
- * @param {*} options
- */
-async function getRequestIDs(gatekeeper, proposalData, options) {
-  // console.log(options);
-  const txOptions = options || {};
-
-  const metadataHashes = proposalData.map(createMultihash);
-  const requests = metadataHashes.map(md => gatekeeper.requestPermission(
-    asBytes(md),
-    txOptions,
-  ));
-
-  const receipts = await Promise.all(requests);
-  const requestIDs = receipts.map((receipt) => {
-    // console.log(receipt);
-    const { requestID } = receipt.logs[0].args;
-    return requestID;
-  });
-
-  return requestIDs;
-}
-
-async function newSlate(gatekeeper, data, options) {
-  const {
-    resource, proposalData, slateData,
-  } = data;
-  const requestIDs = await getRequestIDs(gatekeeper, proposalData, options);
-
-  await gatekeeper.recommendSlate(resource, requestIDs, asBytes(slateData), options);
-  return requestIDs;
-}
-
-
-/**
  * Get the associated resource address by name
  * @param {*} gatekeeper
  * @param {string} name
@@ -579,8 +542,6 @@ const utils = {
   generateCommitHash,
   grantSlateFromProposals,
   governanceSlateFromProposals,
-  getRequestIDs,
-  newSlate,
   getResource,
   voteSingle,
   commitBallot,


### PR DESCRIPTION
This implements the creation of governance proposals by adding a `Proposal` type to the `ParameterStore`. Like in the `TokenCapacitor`, you create a proposal and the `ParameterStore` requests permission from the `Gatekeeper`, to be resolved through slate governance. Once the proposal has been accepted in a slate, you can call `ParameterStore.setValue()` with the request ID and change the parameter value.

It also changes the way the `Gatekeeper` identifies different types of requests, using addresses of _resources_ instead of integer _categories_. The resource in question becomes the contract that is requesting permission -- the address of the `TokenCapacitor` for grants, and the address of the `ParameterStore` for governance parameter changes. This also allows the `Gatekeeper` to reject slates that contain requests for different resources.

* Add `ParameterStore.createProposal()` / `createManyProposals()`
* Add `ParameterStore.setValue()`
* Rename event `ParameterSet` -> `ParameterInitialized` and use new `ParameterSet` in `setValue()`
* Change `category`/`categoryID` to `resource`
* Disallow slates with mixed proposal types