### PR TITLE
Delegated voting

### DIFF
--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -424,11 +424,20 @@ contract Gatekeeper {
         require(didCommit(ballotID, voter) == false, "Voter has already committed for this ballot");
         require(commitHash != 0, "Cannot commit zero hash");
 
-        // If the voter doesn't have enough tokens for voting, deposit more
-        if (voteTokenBalance[voter] < numTokens) {
-            uint remainder = numTokens.sub(voteTokenBalance[voter]);
-            depositVoteTokens(remainder);
+        address committer = msg.sender;
+
+        // Must be a delegate if not the voter
+        if (committer != voter) {
+            require(committer == delegate[voter], "Not a delegate");
+            require(voteTokenBalance[voter] >= numTokens);
+        } else {
+            // If the voter doesn't have enough tokens for voting, deposit more
+            if (voteTokenBalance[voter] < numTokens) {
+                uint remainder = numTokens.sub(voteTokenBalance[voter]);
+                depositVoteTokens(remainder);
+            }
         }
+
         assert(voteTokenBalance[voter] >= numTokens);
 
         // TODO: If the ballot has not been created yet, create it

--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -14,6 +14,7 @@ contract Gatekeeper {
     event SlateStaked(uint slateID, address indexed staker, uint numTokens);
     event VotingTokensDeposited(address indexed voter, uint numTokens);
     event VotingTokensWithdrawn(address indexed voter, uint numTokens);
+    event DelegateSet(address indexed voter, address delegate);
     event BallotCommitted(uint indexed ballotID, address indexed voter, uint numTokens, bytes32 commitHash);
     event BallotRevealed(uint indexed ballotID, address indexed voter, uint numTokens);
     event ContestAutomaticallyFinalized(
@@ -99,6 +100,9 @@ contract Gatekeeper {
 
     // The number of tokens each account has available for voting
     mapping(address => uint) public voteTokenBalance;
+
+    // The delegated account for each voting account
+    mapping(address => address) public delegate;
 
     // The data committed when voting
     struct VoteCommitment {
@@ -391,6 +395,20 @@ contract Gatekeeper {
         return true;
     }
 
+
+    /**
+     @dev Set a delegate account that can vote on behalf of the voter
+     @param _delegate The account being delegated to
+     */
+    function delegateVote(address _delegate) public returns(bool) {
+        address voter = msg.sender;
+        require(voter != _delegate, "Delegate and voter cannot be equal");
+
+        delegate[voter] = _delegate;
+
+        emit DelegateSet(voter, _delegate);
+        return true;
+    }
 
     /**
      @dev Submit a commitment for the current ballot

--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -412,16 +412,14 @@ contract Gatekeeper {
 
     /**
      @dev Submit a commitment for the current ballot
+     @param voter The voter to commit for
      @param commitHash The hash representing the voter's vote choices
      @param numTokens The number of vote tokens to use
      */
-    function commitBallot(bytes32 commitHash, uint numTokens) public {
+    function commitBallot(address voter, bytes32 commitHash, uint numTokens) public {
         uint ballotID = currentEpochNumber();
 
-        uint256 epochTime = now.sub(epochStart(ballotID));
         require(commitPeriodActive(), "Commit period not active");
-
-        address voter = msg.sender;
 
         require(didCommit(ballotID, voter) == false, "Voter has already committed for this ballot");
         require(commitHash != 0, "Cannot commit zero hash");

--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -400,7 +400,7 @@ contract Gatekeeper {
      @dev Set a delegate account that can vote on behalf of the voter
      @param _delegate The account being delegated to
      */
-    function delegateVote(address _delegate) public returns(bool) {
+    function delegateVotingRights(address _delegate) public returns(bool) {
         address voter = msg.sender;
         require(voter != _delegate, "Delegate and voter cannot be equal");
 
@@ -429,7 +429,7 @@ contract Gatekeeper {
         // Must be a delegate if not the voter
         if (committer != voter) {
             require(committer == delegate[voter], "Not a delegate");
-            require(voteTokenBalance[voter] >= numTokens);
+            require(voteTokenBalance[voter] >= numTokens, "Insufficient tokens");
         } else {
             // If the voter doesn't have enough tokens for voting, deposit more
             if (voteTokenBalance[voter] < numTokens) {

--- a/governance-contracts/test/gatekeeper.js
+++ b/governance-contracts/test/gatekeeper.js
@@ -1101,7 +1101,7 @@ contract('Gatekeeper', (accounts) => {
   });
 
   describe('commitBallot', () => {
-    const [creator, voter] = accounts;
+    const [creator, voter, delegate, nonDelegate] = accounts;
     let gatekeeper;
     let token;
     const initialTokens = '20000000';
@@ -1243,6 +1243,86 @@ contract('Gatekeeper', (accounts) => {
       assert.fail('Committed a ballot with a zero commit hash');
     });
 
+    describe('delegated', () => {
+      const commitHash = utils.keccak('data');
+      const numTokens = '1000';
+
+      beforeEach(async () => {
+        await gatekeeper.delegateVote(delegate, { from: voter });
+      });
+
+      it('should let a delegate commit a ballot for the voter', async () => {
+        await gatekeeper.depositVoteTokens(numTokens, { from: voter });
+
+        await increaseTime(timing.VOTING_PERIOD_START);
+        const receipt = await gatekeeper.commitBallot(voter, commitHash, numTokens, {
+          from: delegate,
+        });
+
+        // Emit an event with the correct values
+        const {
+          voter: emittedVoter,
+          numTokens: emittedTokens,
+          commitHash: emittedHash,
+        } = receipt.logs[0].args;
+
+        assert.strictEqual(emittedVoter, voter, 'Emitted voter was wrong');
+        assert.strictEqual(emittedTokens.toString(), numTokens, 'Emitted token amount was wrong');
+        assert.strictEqual(
+          utils.stripHexPrefix(emittedHash),
+          commitHash.toString('hex'),
+          'Emitted hash was wrong',
+        );
+
+        // Correctly store commitment
+        const storedCommitHash = await gatekeeper.getCommitHash(ballotID, voter);
+        assert.strictEqual(
+          utils.stripHexPrefix(storedCommitHash.toString()),
+          commitHash.toString('hex'),
+          'Stored commit hash is wrong',
+        );
+      });
+
+      it('should revert if the delegate has tokens but the voter does not', async () => {
+        // Give the delegate tokens and deposit them
+        const delegateTokens = '10000';
+        await token.transfer(delegate, delegateTokens, { from: creator });
+        await token.approve(gatekeeper.address, delegateTokens, { from: delegate });
+        await gatekeeper.depositVoteTokens(delegateTokens, { from: delegate });
+
+        // Check voter balance
+        const voterBalance = await gatekeeper.voteTokenBalance(voter);
+        assert.strictEqual(voterBalance.toString(), '0', 'Voter should not have any voting tokens');
+
+        // Try to commit for the voter
+        await increaseTime(timing.VOTING_PERIOD_START);
+
+        try {
+          await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: delegate });
+        } catch (error) {
+          expectRevert(error);
+          return;
+        }
+
+        assert.fail('Allowed delegate to vote for a voter with no voting tokens');
+      });
+
+      it('should revert if the committer is not a delegate for the voter', async () => {
+        await gatekeeper.depositVoteTokens(numTokens, { from: voter });
+
+        await increaseTime(timing.VOTING_PERIOD_START);
+
+        try {
+          await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: nonDelegate });
+        } catch (error) {
+          expectRevert(error);
+          expectErrorLike(error, 'Not a delegate');
+          return;
+        }
+        assert.fail('Allowed someone other than the delegate to commit a ballot for the voter');
+      });
+    });
+
     afterEach(async () => {
       await utils.evm.revert(snapshotID);
     });
@@ -1290,6 +1370,23 @@ contract('Gatekeeper', (accounts) => {
     it('should return false if the voter has not committed for the ballot', async () => {
       const didCommit = await gatekeeper.didCommit(ballotID, voter);
       assert.strictEqual(didCommit, false, 'Voter did not commit, but didCommit returned true');
+    });
+
+    it("should return true if a delegate voted on the voter's behalf", async () => {
+      const [, , delegate] = accounts;
+      await gatekeeper.delegateVote(delegate, { from: voter });
+
+      const commitHash = utils.keccak('data');
+      const numTokens = '1000';
+
+      // Advance to commit period
+      await increaseTime(timing.VOTING_PERIOD_START);
+
+      // commit
+      await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: voter });
+
+      const didCommit = await gatekeeper.didCommit(ballotID, voter);
+      assert(didCommit, 'Voter committed, but didCommit returned false');
     });
 
     afterEach(async () => utils.evm.revert(snapshotID));

--- a/governance-contracts/test/gatekeeper.js
+++ b/governance-contracts/test/gatekeeper.js
@@ -1129,7 +1129,7 @@ contract('Gatekeeper', (accounts) => {
       await gatekeeper.depositVoteTokens(numTokens, { from: voter });
 
       await increaseTime(timing.VOTING_PERIOD_START);
-      const receipt = await gatekeeper.commitBallot(commitHash, numTokens, { from: voter });
+      const receipt = await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: voter });
 
       // Emit an event with the correct values
       const {
@@ -1160,7 +1160,7 @@ contract('Gatekeeper', (accounts) => {
       await increaseTime(timing.VOTING_PERIOD_START);
 
       // Do not deposit any vote tokens, but commit anyway
-      await gatekeeper.commitBallot(commitHash, numTokens, { from: voter });
+      await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: voter });
 
       // Voter's token balance has increased
       const finalVotingBalance = await gatekeeper.voteTokenBalance(voter);
@@ -1178,7 +1178,7 @@ contract('Gatekeeper', (accounts) => {
       await gatekeeper.depositVoteTokens(numTokens, { from: voter });
 
       try {
-        await gatekeeper.commitBallot(commitHash, numTokens, { from: voter });
+        await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: voter });
       } catch (error) {
         expectRevert(error);
         expectErrorLike(error, 'not active');
@@ -1197,7 +1197,7 @@ contract('Gatekeeper', (accounts) => {
       await increaseTime(timing.VOTING_PERIOD_START.add(timing.COMMIT_PERIOD_LENGTH));
 
       try {
-        await gatekeeper.commitBallot(commitHash, numTokens, { from: voter });
+        await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: voter });
       } catch (error) {
         expectRevert(error);
         expectErrorLike(error, 'not active');
@@ -1214,11 +1214,11 @@ contract('Gatekeeper', (accounts) => {
       await increaseTime(timing.VOTING_PERIOD_START);
 
       // commit
-      await gatekeeper.commitBallot(commitHash, numTokens, { from: voter });
+      await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: voter });
 
       // try to commit again
       try {
-        await gatekeeper.commitBallot(commitHash, numTokens, { from: voter });
+        await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: voter });
       } catch (error) {
         expectRevert(error);
         return;
@@ -1234,7 +1234,7 @@ contract('Gatekeeper', (accounts) => {
       await increaseTime(timing.VOTING_PERIOD_START);
 
       try {
-        await gatekeeper.commitBallot(commitHash, numTokens, { from: voter });
+        await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: voter });
       } catch (error) {
         expectRevert(error);
         expectErrorLike(error, 'zero hash');
@@ -1281,7 +1281,7 @@ contract('Gatekeeper', (accounts) => {
       await increaseTime(timing.VOTING_PERIOD_START);
 
       // commit
-      await gatekeeper.commitBallot(commitHash, numTokens, { from: voter });
+      await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: voter });
 
       const didCommit = await gatekeeper.didCommit(ballotID, voter);
       assert(didCommit, 'Voter committed, but didCommit returned false');
@@ -1325,7 +1325,7 @@ contract('Gatekeeper', (accounts) => {
       await increaseTime(timing.VOTING_PERIOD_START);
 
       // commit
-      await gatekeeper.commitBallot(commitHash, numTokens, { from: voter });
+      await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: voter });
 
       const storedCommitHash = await gatekeeper.getCommitHash(ballotID, voter);
       assert.strictEqual(
@@ -1457,7 +1457,7 @@ contract('Gatekeeper', (accounts) => {
 
       // commit here
       await increaseTime(timing.VOTING_PERIOD_START);
-      await gatekeeper.commitBallot(commitHash, numTokens, { from: voter });
+      await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: voter });
 
       // set up reveal data
       const resources = Object.keys(votes);
@@ -2049,7 +2049,7 @@ contract('Gatekeeper', (accounts) => {
       await increaseTime(timing.VOTING_PERIOD_START);
 
       // commit
-      await gatekeeper.commitBallot(commitHash, numTokens, { from: voter });
+      await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: voter });
 
       // set up reveal data
       const resources = Object.keys(votes);

--- a/governance-contracts/test/gatekeeper.js
+++ b/governance-contracts/test/gatekeeper.js
@@ -1055,7 +1055,7 @@ contract('Gatekeeper', (accounts) => {
     });
   });
 
-  describe('delegateVote', () => {
+  describe('delegateVotingRights', () => {
     const [creator, voter, delegate] = accounts;
     let gatekeeper;
 
@@ -1064,7 +1064,7 @@ contract('Gatekeeper', (accounts) => {
     });
 
     it('should allow a voter to set a delegate account', async () => {
-      const receipt = await gatekeeper.delegateVote(delegate, { from: voter });
+      const receipt = await gatekeeper.delegateVotingRights(delegate, { from: voter });
 
       assert.strictEqual(receipt.logs[0].event, 'DelegateSet', 'Wrong event was emitted');
       const { voter: emittedVoter, delegate: emittedDelegate } = receipt.logs[0].args;
@@ -1078,7 +1078,7 @@ contract('Gatekeeper', (accounts) => {
 
     it('should revert if the delegate is the same as the sender', async () => {
       try {
-        await gatekeeper.delegateVote(voter, { from: voter });
+        await gatekeeper.delegateVotingRights(voter, { from: voter });
       } catch (error) {
         expectRevert(error);
         expectErrorLike(error, 'equal');
@@ -1089,12 +1089,12 @@ contract('Gatekeeper', (accounts) => {
 
     it('should allow the voter to unset the delegate', async () => {
       // Set delegate
-      const receipt = await gatekeeper.delegateVote(delegate, { from: voter });
+      const receipt = await gatekeeper.delegateVotingRights(delegate, { from: voter });
       const { delegate: setDelegate } = receipt.logs[0].args;
 
       // Unset delegate by setting to zero
       const noDelegate = utils.zeroAddress();
-      await gatekeeper.delegateVote(noDelegate, { from: voter });
+      await gatekeeper.delegateVotingRights(noDelegate, { from: voter });
 
       assert.notStrictEqual(setDelegate, noDelegate, 'Should have unset delegate');
     });
@@ -1248,7 +1248,7 @@ contract('Gatekeeper', (accounts) => {
       const numTokens = '1000';
 
       beforeEach(async () => {
-        await gatekeeper.delegateVote(delegate, { from: voter });
+        await gatekeeper.delegateVotingRights(delegate, { from: voter });
       });
 
       it('should let a delegate commit a ballot for the voter', async () => {
@@ -1301,6 +1301,7 @@ contract('Gatekeeper', (accounts) => {
           await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: delegate });
         } catch (error) {
           expectRevert(error);
+          expectErrorLike(error, 'Insufficient tokens');
           return;
         }
 
@@ -1374,7 +1375,7 @@ contract('Gatekeeper', (accounts) => {
 
     it("should return true if a delegate voted on the voter's behalf", async () => {
       const [, , delegate] = accounts;
-      await gatekeeper.delegateVote(delegate, { from: voter });
+      await gatekeeper.delegateVotingRights(delegate, { from: voter });
 
       const commitHash = utils.keccak('data');
       const numTokens = '1000';

--- a/governance-contracts/test/gatekeeper.js
+++ b/governance-contracts/test/gatekeeper.js
@@ -1055,6 +1055,51 @@ contract('Gatekeeper', (accounts) => {
     });
   });
 
+  describe('delegateVote', () => {
+    const [creator, voter, delegate] = accounts;
+    let gatekeeper;
+
+    beforeEach(async () => {
+      ({ gatekeeper } = await utils.newPanvala({ from: creator }));
+    });
+
+    it('should allow a voter to set a delegate account', async () => {
+      const receipt = await gatekeeper.delegateVote(delegate, { from: voter });
+
+      assert.strictEqual(receipt.logs[0].event, 'DelegateSet', 'Wrong event was emitted');
+      const { voter: emittedVoter, delegate: emittedDelegate } = receipt.logs[0].args;
+
+      assert.strictEqual(emittedVoter, voter, 'Emitted wrong voter');
+      assert.strictEqual(emittedDelegate, delegate, 'Emitted wrong voter');
+
+      const storedDelegate = await gatekeeper.delegate(voter);
+      assert.strictEqual(storedDelegate, delegate, 'Did not set delegate');
+    });
+
+    it('should revert if the delegate is the same as the sender', async () => {
+      try {
+        await gatekeeper.delegateVote(voter, { from: voter });
+      } catch (error) {
+        expectRevert(error);
+        expectErrorLike(error, 'equal');
+        return;
+      }
+      assert.fail('Allowed voter to be its own delegate');
+    });
+
+    it('should allow the voter to unset the delegate', async () => {
+      // Set delegate
+      const receipt = await gatekeeper.delegateVote(delegate, { from: voter });
+      const { delegate: setDelegate } = receipt.logs[0].args;
+
+      // Unset delegate by setting to zero
+      const noDelegate = utils.zeroAddress();
+      await gatekeeper.delegateVote(noDelegate, { from: voter });
+
+      assert.notStrictEqual(setDelegate, noDelegate, 'Should have unset delegate');
+    });
+  });
+
   describe('commitBallot', () => {
     const [creator, voter] = accounts;
     let gatekeeper;

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -412,7 +412,7 @@ async function voteSingle(gatekeeper, voter, resource, firstChoice, secondChoice
   };
 
   const commitHash = generateCommitHash(votes, salt);
-  await gatekeeper.commitBallot(commitHash, numTokens, { from: voter });
+  await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: voter });
 
   return {
     voter,
@@ -439,7 +439,7 @@ async function commitBallot(gatekeeper, voter, ballot, numTokens, salt) {
   });
 
   const commitHash = generateCommitHash(votes, salt);
-  await gatekeeper.commitBallot(commitHash, numTokens, { from: voter });
+  await gatekeeper.commitBallot(voter, commitHash, numTokens, { from: voter });
 
   const resources = Object.keys(votes);
   return {


### PR DESCRIPTION
Allow a voter to delegate another account to vote on their behalf, and allow delegates to vote on behalf of a voter.

* Add `Gatekeeper.delegateVote()`
* Add `voter` argument to `commitBallot()`