### PR TITLE
Add expiration for requests

### DIFF
--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -62,6 +62,7 @@ contract Gatekeeper {
         // The resource (contract) the permission is being requested for
         address resource;
         bool approved;
+        uint expirationTime;
     }
 
     // The requests made to the Gatekeeper. Maps requestID -> Request.
@@ -403,7 +404,6 @@ contract Gatekeeper {
     function commitBallot(bytes32 commitHash, uint numTokens) public {
         uint ballotID = currentEpochNumber();
 
-        uint256 epochTime = now.sub(epochStart(ballotID));
         require(commitPeriodActive(), "Commit period not active");
 
         address voter = msg.sender;
@@ -883,7 +883,8 @@ contract Gatekeeper {
         Request memory r = Request({
             metadataHash: metadataHash,
             resource: resource,
-            approved: false
+            approved: false,
+            expirationTime: 0
         });
 
         // Record request and return its ID
@@ -906,18 +907,20 @@ contract Gatekeeper {
 
         // mark all of its requests as approved
         uint[] memory requestIDs = s.requests;
+        uint256 expirationTime = now.add(EPOCH_LENGTH);
         for (uint i = 0; i < requestIDs.length; i++) {
             uint requestID = requestIDs[i];
             requests[requestID].approved = true;
+            requests[requestID].expirationTime = expirationTime;
         }
     }
 
     /**
-    @dev Return true if the requestID has been approved via slate governance
+    @dev Return true if the requestID has been approved via slate governance and has not expired
     @param requestID The ID of the request to check
      */
     function hasPermission(uint requestID) public view returns(bool) {
-        return requests[requestID].approved;
+        return requests[requestID].approved && now < requests[requestID].expirationTime;
     }
 
 

--- a/governance-contracts/test/gatekeeper.js
+++ b/governance-contracts/test/gatekeeper.js
@@ -894,12 +894,16 @@ contract('Gatekeeper', (accounts) => {
       assert.strictEqual(emittedResource, requestor, 'Emitted resource should match caller address');
 
       // Check Request
-      const { metadataHash: requestHash, resource, approved } = await gatekeeper.requests(
-        requestID,
-      );
+      const {
+        metadataHash: requestHash,
+        resource,
+        approved,
+        expirationTime,
+      } = await gatekeeper.requests(requestID);
       assert.strictEqual(decode(requestHash), metadataHash, 'Metadata hash is incorrect');
       assert.strictEqual(approved, false);
       assert.strictEqual(resource, requestor, 'Requestor is incorrect');
+      assert.strictEqual(expirationTime.toString(), '0', 'Expiration initialized incorrectly');
 
       // Request count was incremented
       const requestCount = await gatekeeper.requestCount();
@@ -2282,6 +2286,18 @@ contract('Gatekeeper', (accounts) => {
       permissions.forEach((has) => {
         assert.strictEqual(has, true, 'Request should have permission');
       });
+
+      // all should have expirations set to an epoch in the future
+      const ts = await utils.evm.timestamp(receipt.receipt.blockNumber);
+      const expectedExpiration = new BN(ts).add(timing.EPOCH_LENGTH);
+      const requests = await Promise.all(slateRequests.map(r => gatekeeper.requests(r)));
+      requests.forEach((request) => {
+        assert.strictEqual(
+          request.expirationTime.toString(),
+          expectedExpiration.toString(),
+          'Expiration should have been an epoch in the future',
+        );
+      });
     });
 
     it('should revert if the resource has no staked slates', async () => {
@@ -2923,6 +2939,18 @@ contract('Gatekeeper', (accounts) => {
       permissions.forEach((has) => {
         assert.strictEqual(has, true, 'Request should have permission');
       });
+
+      // all should have expirations set to an epoch in the future
+      const ts = await utils.evm.timestamp(receipt.receipt.blockNumber);
+      const expectedExpiration = new BN(ts).add(timing.EPOCH_LENGTH);
+      const requests = await Promise.all(slateRequests.map(r => gatekeeper.requests(r)));
+      requests.forEach((request) => {
+        assert.strictEqual(
+          request.expirationTime.toString(),
+          expectedExpiration.toString(),
+          'Expiration should have been an epoch in the future',
+        );
+      });
     });
 
     it('should count correctly if the original leader wins the runoff', async () => {
@@ -3237,22 +3265,37 @@ contract('Gatekeeper', (accounts) => {
 
         // Advance past reveal period
         await increaseTime(timing.REVEAL_PERIOD_LENGTH);
+        await gatekeeper.countVotes(ballotID, GRANT);
       });
 
       it('should return true for a request that was included in an accepted slate', async () => {
-        await gatekeeper.countVotes(ballotID, GRANT);
-
         const requestID = 0;
         const hasPermission = await gatekeeper.hasPermission.call(requestID);
         assert.strictEqual(hasPermission, true, 'Request should have been approved');
       });
 
       it('should return false for a request that was included in a rejected slate', async () => {
-        await gatekeeper.countVotes(ballotID, GRANT);
-
         const requestID = 3;
         const hasPermission = await gatekeeper.hasPermission.call(requestID);
         assert.strictEqual(hasPermission, false, 'Request should NOT have been approved');
+      });
+
+      it('should return false for an approved request that has expired', async () => {
+        const requestID = 0;
+
+        // Request is initially approved
+        const initialPermission = await gatekeeper.hasPermission(requestID);
+        assert.strictEqual(initialPermission, true, 'Request should have been approved');
+
+        // Move forward
+        await increaseTime(timing.EPOCH_LENGTH);
+        const request = await gatekeeper.requests(requestID);
+        const now = await utils.evm.timestamp();
+        assert(now >= request.expirationTime, 'Not past expiration time');
+
+        // Check expired request
+        const hasPermission = await gatekeeper.hasPermission(requestID);
+        assert.strictEqual(hasPermission, false, 'Expired request should not have been approved');
       });
     });
 
@@ -3288,6 +3331,24 @@ contract('Gatekeeper', (accounts) => {
         const requestID = 0;
         const hasPermission = await gatekeeper.hasPermission.call(requestID);
         assert.strictEqual(hasPermission, false, 'Request should NOT have been approved');
+      });
+
+      it('should return false for an approved request that has expired', async () => {
+        const requestID = 3;
+
+        // Request is initially approved
+        const initialPermission = await gatekeeper.hasPermission(requestID);
+        assert.strictEqual(initialPermission, true, 'Request should have been approved');
+
+        // Move forward
+        await increaseTime(timing.EPOCH_LENGTH);
+        const request = await gatekeeper.requests(requestID);
+        const now = await utils.evm.timestamp();
+        assert(now >= request.expirationTime, 'Not past expiration time');
+
+        // Check expired request
+        const hasPermission = await gatekeeper.hasPermission(requestID);
+        assert.strictEqual(hasPermission, false, 'Expired request should not have been approved');
       });
     });
 


### PR DESCRIPTION
Requests now have an expiration time one epoch (13 weeks) after the containing slate is approved. `Gatekeeper.hasPermission()` returns false for any requests whose expiration time has passed.