### PR TITLE
setup code for incumbent flag

### DIFF
--- a/api/controllers/notification.js
+++ b/api/controllers/notification.js
@@ -20,9 +20,12 @@ module.exports = {
     try {
       getAllEvents().then(events => {
         events.map(e => {
+          // print out event name and block.timestamp
           console.log(e.name, e.timestamp);
+          // print out event values for debugging
           Object.keys(e.values).map(arg => {
             let value = e.values[arg];
+            // filter out numerical duplicates, like { 0: '0x1234', voter: '0x1234' }, and the `length` field
             if (numRegex.test(arg) && arg !== 'length') {
               if (value.hasOwnProperty('_hex')) {
                 value = value.toString();

--- a/api/controllers/notification.js
+++ b/api/controllers/notification.js
@@ -2,6 +2,8 @@ const { utils } = require('ethers');
 const { getAllEvents } = require('../utils/transactions');
 const { getNormalizedNotificationsByEvents } = require('../utils/notifications');
 
+const numRegex = /^([^0-9]*)$/;
+
 module.exports = {
   /**
    * Get all notifications for a user's address
@@ -19,8 +21,17 @@ module.exports = {
       getAllEvents().then(events => {
         events.map(e => {
           console.log(e.name, e.timestamp);
+          Object.keys(e.values).map(arg => {
+            let value = e.values[arg];
+            if (numRegex.test(arg) && arg !== 'length') {
+              if (value.hasOwnProperty('_hex')) {
+                value = value.toString();
+              }
+              console.log(arg, value);
+            }
+          });
+          console.log('');
         });
-        console.log('');
         console.log('events:', events.length);
         console.log('');
         getNormalizedNotificationsByEvents(events, address).then(notifications => {

--- a/api/package.json
+++ b/api/package.json
@@ -19,6 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "ajv": "^6.10.0",
+    "bluebird": "^3.5.5",
     "cors": "^2.8.5",
     "ethers": "^4.0.26",
     "express": "^4.16.4",

--- a/api/utils/slates.js
+++ b/api/utils/slates.js
@@ -39,8 +39,11 @@ async function getAllSlates() {
   console.log(`fetching ${slateCount} slates`);
   const currentEpoch = await gatekeeper.functions.currentEpochNumber();
   console.log('currentEpoch:', currentEpoch);
-  // const grantsIncumbent = await gatekeeper.functions.incumbent(tokenCapacitorAddress);
-  // const governanceIncumbent = await gatekeeper.functions.incumbent(parameterStoreAddress);
+  let grantsIncumbent, governanceIncumbent;
+  if (gatekeeper.functions.hasOwnProperty('incumbent')) {
+    grantsIncumbent = await gatekeeper.functions.incumbent(tokenCapacitorAddress);
+    governanceIncumbent = await gatekeeper.functions.incumbent(parameterStoreAddress);
+  }
 
   // 0..slateCount
   const slateIDs = range(0, slateCount);
@@ -56,11 +59,14 @@ async function getAllSlates() {
       const decoded = toUtf8String(slate.metadataHash);
       console.log('decoded hash', decoded);
       let incumbent = false;
-      // if (recommender === grantsIncumbent && resource === tokenCapacitorAddress) {
-      //   incumbent = true;
-      // } else if (recommender === governanceIncumbent && resource === parameterStoreAddress) {
-      //   incumbent = true;
-      // }
+      if (slate.recommender === grantsIncumbent && slate.resource === tokenCapacitorAddress) {
+        incumbent = true;
+      } else if (
+        slate.recommender === governanceIncumbent &&
+        slate.resource === parameterStoreAddress
+      ) {
+        incumbent = true;
+      }
       console.log('slate:', slate);
       return getSlateWithMetadata(slateID, slate, decoded, incumbent, requiredStake);
     },

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -767,6 +767,11 @@ bluebird@^3.5.0, bluebird@^3.5.3:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
   integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
 
+bluebird@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
+
 bn.js@^4.0.0, bn.js@^4.11.3, bn.js@^4.11.8, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"

--- a/client/components/stories/Card.stories.tsx
+++ b/client/components/stories/Card.stories.tsx
@@ -22,7 +22,7 @@ storiesOf('Card', module)
           description={newSlate.description}
           category={newSlate.category}
           status={convertEVMSlateStatus(newSlate.status)}
-          address={newSlate.recommenderAddress}
+          address={newSlate.recommender}
           recommender={newSlate.organization}
           verifiedRecommender={newSlate.verifiedRecommender}
           type={SLATE}
@@ -46,7 +46,7 @@ storiesOf('Card', module)
           description={newSlate.description}
           category={newSlate.category}
           status={convertEVMSlateStatus(newSlate.status)}
-          address={newSlate.recommenderAddress}
+          address={newSlate.recommender}
           recommender={newSlate.organization}
           verifiedRecommender={newSlate.verifiedRecommender}
           type={SLATE}
@@ -70,7 +70,7 @@ storiesOf('Card', module)
           description={newSlate.description}
           category={newSlate.category}
           status={convertEVMSlateStatus(newSlate.status)}
-          address={newSlate.recommenderAddress}
+          address={newSlate.recommender}
           recommender={newSlate.organization}
           verifiedRecommender={newSlate.verifiedRecommender}
           type={SLATE}
@@ -94,7 +94,7 @@ storiesOf('Card', module)
           description={newSlate.description}
           category={newSlate.category}
           status={convertEVMSlateStatus(newSlate.status)}
-          address={newSlate.recommenderAddress}
+          address={newSlate.recommender}
           recommender={newSlate.organization}
           verifiedRecommender={newSlate.verifiedRecommender}
           type={SLATE}
@@ -124,7 +124,7 @@ storiesOf('Card', module)
           description={newSlate.description}
           category={newSlate.category}
           status={convertEVMSlateStatus(newSlate.status)}
-          address={newSlate.recommenderAddress}
+          address={newSlate.recommender}
           recommender={newSlate.organization}
           verifiedRecommender={newSlate.verifiedRecommender}
           type={SLATE}

--- a/client/components/stories/data.tsx
+++ b/client/components/stories/data.tsx
@@ -35,7 +35,7 @@ export const unstakedSlate: ISlate = {
   deadline: currentBallot.votingOpenDate,
   title: 'Some slate',
   owner: 'John Doe',
-  recommenderAddress: '0xd115bffabbdd893a6f7cea402e7338643ced44a6',
+  recommender: '0xd115bffabbdd893a6f7cea402e7338643ced44a6',
   organization: 'Team Recommender',
   description:
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eu nibh molestie, auctor ligula a, faucibus ante. Morbi dapibus enim in vulputate congue. Mauris feugiat gravida nibh, sed pellentesque eros pellentesque eu. Sed rutrum vitae magna sed aliquet. Suspendisse facilisis vulputate lobortis. Vestibulum sed dolor eu mi molestie pharetra. Duis ut diam aliquam, molestie erat non, scelerisque ligula. Curabitur accumsan ipsum pellentesque posuere ornare. Sed vulputate cursus accumsan. Morbi efficitur dictum magna, a imperdiet mauris aliquet vitae.',

--- a/client/interfaces/contexts.ts
+++ b/client/interfaces/contexts.ts
@@ -79,7 +79,7 @@ export interface ISlate {
   proposals: IProposal[];
   requiredStake: utils.BigNumberish;
   verifiedRecommender: boolean;
-  recommenderAddress: string;
+  recommender: string;
   staker?: string;
 }
 

--- a/client/pages/ballots/vote.tsx
+++ b/client/pages/ballots/vote.tsx
@@ -226,7 +226,7 @@ const Vote: React.FunctionComponent<IProps> = ({ router }) => {
                       category={slate.category}
                       status={convertEVMSlateStatus(slate.status)}
                       choices={choices}
-                      address={slate.recommenderAddress}
+                      address={slate.recommender}
                       onSetChoice={handleSetChoice}
                       proposals={slate.proposals}
                       slateID={slate.id.toString()}

--- a/client/pages/slates/index.tsx
+++ b/client/pages/slates/index.tsx
@@ -71,7 +71,7 @@ const Slates: React.SFC = () => {
                     description={slate.description}
                     category={slate.category}
                     status={convertEVMSlateStatus(slate.status)}
-                    address={slate.recommenderAddress}
+                    address={slate.recommender}
                     recommender={slate.organization}
                     verifiedRecommender={slate.verifiedRecommender}
                     type={SLATE}

--- a/client/pages/slates/slate.tsx
+++ b/client/pages/slates/slate.tsx
@@ -140,7 +140,7 @@ export const SlateSidebar = ({ slate, requiredStake, currentBallot }: IStakeSide
         <TokensSection>
           <SectionLabel lessMargin>{'CREATED BY'}</SectionLabel>
           <Box color="black">{slate.owner}</Box>
-          <CardAddress>{splitAddressHumanReadable(slate.recommenderAddress)}</CardAddress>
+          <CardAddress>{splitAddressHumanReadable(slate.recommender)}</CardAddress>
 
           {slate.verifiedRecommender ? (
             <>


### PR DESCRIPTION
use bluebird `.map`, `.delay`, and `concurrency` to throttle getting slates:
- up to 5 promises can run concurrently to get slate data
- all or nothing for now
- match frontend `recommender` field

once #80 is merged, we can uncomment the relevant code in `/api/utils/slates.js`