### PR TITLE
Update permissions API

### DIFF
--- a/docs/permissions-api.md
+++ b/docs/permissions-api.md
@@ -1,0 +1,106 @@
+# Panvala Permissions API
+Using the Permissions API, you can create contracts that have functions that can only be executed through permission granted by the gatekeeper (and therefore, the larger Panvala community).
+
+## General flow
+A user makes a proposal, and the contract requests permission from the gatekeeper and stores the `requestID` it receives. The user gets back a `proposalID` to use to execute the proposal later. If the request is approved through being included in an accepted slate, the proposal is accepted. The user can now pass the `proposalID` to a function on the contract to execute the proposal. In that execution function, the contract checks whether the `requestID` associated with its `proposalID` has permission, and then executes the rest of the function if it has.
+
+## Usage
+Define proposals for your contract. Users of the contract will need to create proposals, including a metadata hash (e.g. IPFS CID) describing the nature of the proposal.
+
+You can define your data structures any way you want, but it should contain the address of the current gatekeeper, as well as the `requestID` it received from requesting permission, the metadata hash submitted with the proposal, any data required to execute the proposal later, and some way to prevent the proposal from being executed twice.
+
+
+Below are some examples from `ParameterStore.sol`
+```
+struct Proposal {
+    // request identification
+    address gatekeeper;
+    uint256 requestID;
+    // proposal data
+    bytes metadataHash;
+    string key;
+    bytes32 value;
+    // some way to prevent proposals from being executed twice
+    bool executed;
+}
+```
+
+Provide a function for submitting proposals. It should emit an event `ProposalCreated` and return `proposalID`.
+```
+event ProposalCreated(
+    uint256 proposalID,
+    address indexed proposer,
+    uint256 requestID,
+    // proposal data
+    string key,
+    bytes32 value,
+    bytes metadataHash
+);
+```
+
+```
+function createProposal(string memory key, bytes32 value, bytes memory metadataHash) public returns(uint256) {
+    require(metadataHash.length > 0, "metadataHash cannot be empty");
+
+    Gatekeeper gatekeeper = _gatekeeper();
+    Proposal memory p = Proposal({
+        gatekeeper: address(gatekeeper),
+        requestID: 0,
+        key: key,
+        value: value,
+        metadataHash: metadataHash,
+        executed: false
+    });
+
+    // Request permission from the Gatekeeper and store the proposal data for later.
+    // If the request is approved, a user can execute the proposal by providing the
+    // proposalID.
+    uint requestID = gatekeeper.requestPermission(metadataHash);
+    p.requestID = requestID;
+    uint proposalID = proposalCount;
+    proposals[proposalID] = p;
+    proposalCount = proposalCount.add(1);
+
+    emit ProposalCreated(proposalID, msg.sender, requestID, key, value, metadataHash);
+    return proposalID;
+}
+```
+
+It's helpful to have a function to create many proposals at once.
+```
+function createManyProposals(
+    string[] memory keys,
+    bytes32[] memory values,
+    bytes[] memory metadataHashes
+) public {
+    require(keys.length == values.length, "All inputs must have the same length");
+    require(values.length == metadataHashes.length, "All inputs must have the same length");
+
+    for (uint i = 0; i < keys.length; i++) {
+        string memory key = keys[i];
+        bytes32 value = values[i];
+        bytes memory metadataHash = metadataHashes[i];
+        createProposal(key, value, metadataHash);
+    }
+}
+```
+
+Finally, execute the proposal. The execution function should emit an event including the `proposalID` and some data for context.
+```
+function setValue(uint256 proposalID) public returns(bool) {
+    require(proposalID < proposalCount, "Invalid proposalID");
+
+    Proposal memory p = proposals[proposalID];
+    Gatekeeper gatekeeper = Gatekeeper(p.gatekeeper);
+
+    require(gatekeeper.hasPermission(p.requestID), "Proposal has not been approved");
+    require(p.executed == false, "Proposal already executed");
+
+    proposals[proposalID].executed = true;
+
+    set(p.key, p.value);
+
+    emit ParameterSet(proposalID, p.key, p.value);
+    return true;
+}
+```

--- a/governance-contracts/test/parameterStore.js
+++ b/governance-contracts/test/parameterStore.js
@@ -146,12 +146,12 @@ contract('ParameterStore', (accounts) => {
 
   describe('createProposal', () => {
     const [creator, proposer] = accounts;
-    // let gatekeeper;
+    let gatekeeper;
     let parameters;
 
     beforeEach(async () => {
       // deploy
-      ({ parameters } = await utils.newPanvala({ from: creator }));
+      ({ parameters, gatekeeper } = await utils.newPanvala({ from: creator }));
     });
 
     it('it should create a proposal to change a parameter', async () => {
@@ -193,6 +193,7 @@ contract('ParameterStore', (accounts) => {
 
       // should save proposal with values
       const proposal = await parameters.proposals(requestID);
+      assert.strictEqual(proposal.gatekeeper, gatekeeper.address, 'Proposal has wrong gatekeeper');
       assert.strictEqual(proposal.key, key, 'Proposal has wrong key');
       assert.strictEqual(proposal.value, encodedValue, 'Proposal has wrong value');
       assert.strictEqual(

--- a/governance-contracts/test/parameterStore.js
+++ b/governance-contracts/test/parameterStore.js
@@ -170,6 +170,7 @@ contract('ParameterStore', (accounts) => {
       // Should emit event with requestID and other data
       assert.strictEqual(receipt.logs[0].event, 'ProposalCreated');
       const {
+        proposalID,
         proposer: emittedProposer,
         requestID,
         key: emittedKey,
@@ -177,7 +178,8 @@ contract('ParameterStore', (accounts) => {
         metadataHash: emittedHash,
       } = receipt.logs[0].args;
 
-      assert.strictEqual(requestID.toString(), '0');
+      assert.strictEqual(requestID.toString(), '0', 'Emitted wrong requestID');
+      assert.strictEqual(proposalID.toString(), '0', 'Emitted wrong proposalID');
       assert.strictEqual(emittedProposer, proposer, 'Emitted wrong proposer');
       assert.strictEqual(emittedKey, key, 'Emitted wrong key');
       assert.strictEqual(emittedValue.toString(), encodedValue, 'Emitted wrong value');
@@ -194,6 +196,7 @@ contract('ParameterStore', (accounts) => {
       // should save proposal with values
       const proposal = await parameters.proposals(requestID);
       assert.strictEqual(proposal.gatekeeper, gatekeeper.address, 'Proposal has wrong gatekeeper');
+      assert.strictEqual(proposal.requestID.toString(), '0', 'Proposal has wrong requestID');
       assert.strictEqual(proposal.key, key, 'Proposal has wrong key');
       assert.strictEqual(proposal.value, encodedValue, 'Proposal has wrong value');
       assert.strictEqual(
@@ -255,6 +258,7 @@ contract('ParameterStore', (accounts) => {
           const metadataHash = metadataHashes[i];
 
           const {
+            proposalID,
             proposer: emittedProposer,
             requestID,
             key: emittedKey,
@@ -264,7 +268,8 @@ contract('ParameterStore', (accounts) => {
 
           // should emit event with requestID and other data
           const index = i.toString();
-          assert.strictEqual(requestID.toString(), index);
+          assert.strictEqual(requestID.toString(), index, 'Emitted wrong requestID');
+          assert.strictEqual(proposalID.toString(), index, 'Emitted wrong proposalID');
           assert.strictEqual(emittedProposer, proposer, 'Emitted wrong proposer');
           assert.strictEqual(emittedKey, key, 'Emitted wrong key');
           assert.strictEqual(emittedValue.toString(), value, 'Emitted wrong value');

--- a/governance-contracts/test/tokenCapacitor.js
+++ b/governance-contracts/test/tokenCapacitor.js
@@ -92,9 +92,10 @@ contract('TokenCapacitor', (accounts) => {
   describe('createProposal', () => {
     const [creator, beneficiary] = accounts;
     let capacitor;
+    let gatekeeper;
 
     beforeEach(async () => {
-      ({ capacitor } = await utils.newPanvala({ from: creator }));
+      ({ capacitor, gatekeeper } = await utils.newPanvala({ from: creator }));
     });
 
     it('should create a proposal to the appropriate beneficiary', async () => {
@@ -134,6 +135,7 @@ contract('TokenCapacitor', (accounts) => {
 
       // should save proposal with values
       const proposal = await capacitor.proposals(requestID);
+      assert.strictEqual(proposal.gatekeeper, gatekeeper.address, 'Proposal has wrong gatekeeper');
       assert.strictEqual(proposal.tokens.toString(), tokens, 'Proposal has wrong number of tokens');
       assert.strictEqual(proposal.to, to, 'Proposal has wrong beneficiary');
       assert.strictEqual(

--- a/governance-contracts/test/tokenCapacitor.js
+++ b/governance-contracts/test/tokenCapacitor.js
@@ -111,6 +111,7 @@ contract('TokenCapacitor', (accounts) => {
       );
 
       const {
+        proposalID,
         proposer,
         requestID,
         recipient: emittedRecipient,
@@ -119,7 +120,8 @@ contract('TokenCapacitor', (accounts) => {
       } = receipt.logs[0].args;
 
       // should emit event with requestID and other data
-      assert.strictEqual(requestID.toString(), '0');
+      assert.strictEqual(proposalID.toString(), '0', 'Emitted wrong proposalID');
+      assert.strictEqual(requestID.toString(), '0', 'Emitted wrong requestID');
       assert.strictEqual(proposer, creator, 'Emitted wrong proposer');
       assert.strictEqual(emittedRecipient, to, 'Emitted wrong beneficiary');
       assert.strictEqual(emittedTokens.toString(), tokens, 'Emitted wrong number of tokens');
@@ -136,6 +138,7 @@ contract('TokenCapacitor', (accounts) => {
       // should save proposal with values
       const proposal = await capacitor.proposals(requestID);
       assert.strictEqual(proposal.gatekeeper, gatekeeper.address, 'Proposal has wrong gatekeeper');
+      assert.strictEqual(proposal.requestID.toString(), '0', 'Proposal has wrong requestID');
       assert.strictEqual(proposal.tokens.toString(), tokens, 'Proposal has wrong number of tokens');
       assert.strictEqual(proposal.to, to, 'Proposal has wrong beneficiary');
       assert.strictEqual(
@@ -211,6 +214,7 @@ contract('TokenCapacitor', (accounts) => {
         const metadataHash = metadataHashes[i];
 
         const {
+          proposalID,
           proposer: emittedProposer,
           requestID,
           recipient: emittedRecipient,
@@ -220,7 +224,8 @@ contract('TokenCapacitor', (accounts) => {
 
         // should emit event with requestID and other data
         const index = i.toString();
-        assert.strictEqual(requestID.toString(), index);
+        assert.strictEqual(requestID.toString(), index, 'Emitted wrong requestID');
+        assert.strictEqual(proposalID.toString(), index, 'Emitted wrong proposalID');
         assert.strictEqual(emittedProposer, proposer, 'Emitted wrong proposer');
         assert.strictEqual(emittedRecipient, to, 'Emitted wrong beneficiary');
         assert.strictEqual(emittedTokens.toString(), tokens, 'Emitted wrong number of tokens');

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -345,6 +345,7 @@ const proposalCategories = {
  * Create a grant proposal slate from proposal info
  * options include: gatekeeper, capacitor, proposals, recommender, metadata, batchNumber
  * @param {*} options
+ * @returns proposalIDs
  */
 async function grantSlateFromProposals(options) {
   const {
@@ -375,13 +376,15 @@ async function grantSlateFromProposals(options) {
     { from: recommender },
   );
 
-  return requestIDs;
+  const proposalIDs = receipt.logs.map(l => l.args.proposalID);
+  return proposalIDs;
 }
 
 /**
  * Create a governance proposal slate from proposal info
  * options include: gatekeeper, parameterStore, proposals, recommender, metadata
  * @param {*} options
+ * @returns proposalIDs
  */
 async function governanceSlateFromProposals(options) {
   const {
@@ -413,7 +416,8 @@ async function governanceSlateFromProposals(options) {
     { from: recommender },
   );
 
-  return requestIDs;
+  const proposalIDs = receipt.logs.map(l => l.args.proposalID);
+  return proposalIDs;
 }
 
 /**


### PR DESCRIPTION
Make modifications to the permissions API to make sure multiple contracts can 1) interact with the Gatekeeper in parallel and 2) deal with an upgraded the Gatekeeper.

For `TokenCapacitor` and `ParameterStore`:

* Store `gatekeeper` and `requestID` in `Proposal` struct
* Return `proposalID` from `createProposal()` and add to `ProposalCreated` event
* Add integration test with parallel contests
* Add documentation