### PR TITLE
Hardcode token address in Gatekeeper and TokenCapacitor

### DIFF
--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -175,6 +175,7 @@ contract Gatekeeper {
      @param _parameters The parameter store to use
     */
     constructor(uint _startTime, ParameterStore _parameters) public {
+        require(address(_parameters) != address(0), "Parameter store address cannot be zero");
         parameters = _parameters;
 
         address tokenAddress = parameters.getAsAddress("tokenAddress");

--- a/governance-contracts/contracts/TokenCapacitor.sol
+++ b/governance-contracts/contracts/TokenCapacitor.sol
@@ -64,6 +64,7 @@ contract TokenCapacitor {
 
     // IMPLEMENTATION
     constructor(ParameterStore _parameters, IERC20 _token) public {
+        require(address(_parameters) != address(0), "Parameter store address cannot be zero");
         parameters = _parameters;
 
         require(address(_token) != address(0), "Token address cannot be zero");

--- a/governance-contracts/contracts/dev/TimeTravelingGatekeeper.sol
+++ b/governance-contracts/contracts/dev/TimeTravelingGatekeeper.sol
@@ -14,8 +14,8 @@ contract TimeTravelingGatekeeper is Gatekeeper {
 
     event TimeTraveled(int256 amount, uint256 startTime);
 
-    constructor(uint _startTime, ParameterStore _parameters)
-        Gatekeeper(_startTime, _parameters) public {
+    constructor(uint _startTime, ParameterStore _parameters, IERC20 _token)
+        Gatekeeper(_startTime, _parameters, _token) public {
 
         owner = msg.sender;
     }

--- a/governance-contracts/contracts/test/UpgradedGatekeeper.sol
+++ b/governance-contracts/contracts/test/UpgradedGatekeeper.sol
@@ -20,8 +20,8 @@ contract UpgradedGatekeeper is Gatekeeper {
     bool initialized;
     uint256 epochToTransfer;
 
-    constructor(ParameterStore _parameters)
-        Gatekeeper(0, _parameters) public {
+    constructor(ParameterStore _parameters, IERC20 _token)
+        Gatekeeper(0, _parameters, _token) public {
 
         // get the old gatekeeper
         address gatekeeperAddress = _parameters.getAsAddress("gatekeeperAddress");

--- a/governance-contracts/migrations/4_gatekeeper.js
+++ b/governance-contracts/migrations/4_gatekeeper.js
@@ -3,29 +3,39 @@
 const Gatekeeper = artifacts.require('Gatekeeper');
 const ParameterStore = artifacts.require('ParameterStore');
 const DevGatekeeper = artifacts.require('TimeTravelingGatekeeper');
+const BasicToken = artifacts.require('BasicToken');
 
 
 const { abiEncode } = require('../utils');
 
 // eslint-disable-next-line func-names
 module.exports = async function (deployer, networks) {
-  const { gatekeeper: config } = global.panvalaConfig;
+  const { gatekeeper: config, token: tokenInfo } = global.panvalaConfig;
   const { firstEpochStart } = config;
 
   const firstEpochTime = new Date(firstEpochStart);
   const startTime = Math.floor(firstEpochTime / 1000);
   // console.log(startTime);
 
+  const token = tokenInfo.deploy
+    ? await BasicToken.deployed()
+    : await BasicToken.at(tokenInfo.address);
+
   const parameters = await ParameterStore.deployed();
 
-  console.log(`Deploying Gatekeeper with ParameterStore ${parameters.address}`);
+  console.log(`Deploying Gatekeeper with ParameterStore ${parameters.address} and token ${token.address}`);
 
   // Enable time travel on development networks
   // eslint-disable-next-line operator-linebreak
   const GatekeeperArtifact =
     networks === 'development' || networks === 'ganache' ? DevGatekeeper : Gatekeeper;
 
-  const gatekeeper = await deployer.deploy(GatekeeperArtifact, startTime, parameters.address);
+  const gatekeeper = await deployer.deploy(
+    GatekeeperArtifact,
+    startTime,
+    parameters.address,
+    token.address,
+  );
   await parameters.setInitialValue(
     'gatekeeperAddress',
     abiEncode('address', gatekeeper.address),

--- a/governance-contracts/migrations/5_token_capacitor.js
+++ b/governance-contracts/migrations/5_token_capacitor.js
@@ -11,7 +11,13 @@ module.exports = async function(deployer, _, accounts) {
   const parameters = await ParameterStore.deployed();
   console.log(`Deploying TokenCapacitor with ParameterStore ${parameters.address}`);
 
-  const capacitor = await deployer.deploy(TokenCapacitor, parameters.address);
+  const { capacitor: config, token: tokenInfo } = global.panvalaConfig;
+
+  const token = tokenInfo.deploy
+    ? await BasicToken.deployed()
+    : await BasicToken.at(tokenInfo.address);
+
+  const capacitor = await deployer.deploy(TokenCapacitor, parameters.address, token.address);
 
   await parameters.setInitialValue(
     'tokenCapacitorAddress',
@@ -19,14 +25,10 @@ module.exports = async function(deployer, _, accounts) {
   );
 
   // Charge the capacitor
-  const { capacitor: config, token: tokenInfo } = global.panvalaConfig;
   const { charge, initialBalance } = config;
 
   if (charge) {
     console.log(`Charging capacitor with ${initialBalance} tokens`);
-    const token = tokenInfo.deploy
-      ? await BasicToken.deployed()
-      : await BasicToken.at(tokenInfo.address);
 
     // if the creator has enough balance, then charge
     const [creator] = accounts;

--- a/governance-contracts/test/dev/timeTravelingGatekeeper.js
+++ b/governance-contracts/test/dev/timeTravelingGatekeeper.js
@@ -20,22 +20,18 @@ const { ONE_WEEK } = timing;
 
 contract('TimeTravelGatekeeper', (accounts) => {
   const [creator] = accounts;
+  let token;
   let parameters;
   let gatekeeper;
   let GRANT;
 
   before(async () => {
     const stakeAmount = '5000';
-    const token = await BasicToken.deployed();
+    token = await BasicToken.deployed();
 
     parameters = await ParameterStore.new(
       ['slateStakeAmount'],
       [abiCoder.encode(['uint256'], [stakeAmount])],
-      { from: creator },
-    );
-    await parameters.setInitialValue(
-      'tokenAddress',
-      abiCoder.encode(['address'], [token.address]),
       { from: creator },
     );
     await parameters.init({ from: creator });
@@ -48,6 +44,7 @@ contract('TimeTravelGatekeeper', (accounts) => {
     gatekeeper = await TimeTravelingGatekeeper.new(
       startTime,
       parameters.address,
+      token.address,
       { from: creator },
     );
 

--- a/governance-contracts/test/gatekeeper.js
+++ b/governance-contracts/test/gatekeeper.js
@@ -152,6 +152,7 @@ contract('Gatekeeper', (accounts) => {
         await Gatekeeper.new(startTime, parameterStoreAddress, { from: creator });
       } catch (error) {
         expectRevert(error);
+        expectErrorLike(error, 'parameter store address');
         return;
       }
       assert.fail('Created Gatekeeper with a zero parameter store address');
@@ -169,7 +170,7 @@ contract('Gatekeeper', (accounts) => {
         await Gatekeeper.new(startTime, badParameters.address, { from: creator });
       } catch (error) {
         expectRevert(error);
-
+        expectErrorLike(error, 'token address');
         return;
       }
       assert.fail('Created Gatekeeper with a zero token address');

--- a/governance-contracts/test/integration.js
+++ b/governance-contracts/test/integration.js
@@ -346,7 +346,7 @@ contract('integration', (accounts) => {
 
       // deploy new gatekeeper with the same starting time as the old one
       const systemStart = await gatekeeper.startTime();
-      const newGatekeeper = await Gatekeeper.new(systemStart, parameters.address, {
+      const newGatekeeper = await Gatekeeper.new(systemStart, parameters.address, token.address, {
         from: creator,
       });
 
@@ -493,7 +493,7 @@ contract('integration', (accounts) => {
         await token.approve(gatekeeper.address, '10000', { from: creator });
 
         // deploy newer and shinier gatekeeper
-        newGatekeeper = await UpgradedGatekeeper.new(parameters.address, {
+        newGatekeeper = await UpgradedGatekeeper.new(parameters.address, token.address, {
           from: creator,
         });
 

--- a/governance-contracts/test/tokenCapacitor.js
+++ b/governance-contracts/test/tokenCapacitor.js
@@ -58,6 +58,19 @@ contract('TokenCapacitor', (accounts) => {
       assert.strictEqual(proposalCount.toString(), '0', 'There should be no proposals yet');
     });
 
+    it('should fail if the parameter store address is zero', async () => {
+      const badParameters = utils.zeroAddress();
+
+      try {
+        await TokenCapacitor.new(badParameters, token.address, { from: creator });
+      } catch (error) {
+        expectRevert(error);
+        expectErrorLike(error, 'parameter store address');
+        return;
+      }
+      assert.fail('Created TokenCapacitor with a zero parameter store address');
+    });
+
     it('should fail if the token address is zero', async () => {
       const badToken = utils.zeroAddress();
 

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -299,7 +299,7 @@ async function newPanvala(options) {
   const parameters = await ParameterStore.at(parametersAddress);
   const tokenAddress = await parameters.getAsAddress('tokenAddress');
   const token = await BasicToken.at(tokenAddress);
-  const capacitor = await TokenCapacitor.new(parameters.address, { from: creator });
+  const capacitor = await TokenCapacitor.new(parameters.address, token.address, { from: creator });
 
   await parameters.setInitialValue(
     'tokenCapacitorAddress',


### PR DESCRIPTION
Instead of reading the token address from the `ParameterStore`, pass it in when creating the `TokenCapacitor` and the `Gatekeeper`.