### PR TITLE
estimate and render total available grant tokens:

### DIFF
--- a/client/pages/slates/create/grant.tsx
+++ b/client/pages/slates/create/grant.tsx
@@ -134,12 +134,7 @@ const CreateGrantSlate: StatelessPage<IProps> = ({ query, classes, router }) => 
           contracts.tokenCapacitor.address
         );
         winningSlate = slatesByID[winningSlateID.toString()];
-      } catch {
-        // if the query reverts, try to find the slate manually
-        winningSlate = slates.find(
-          s => s.status === SlateStatus.Accepted && s.epochNumber === lastEpoch
-        );
-      }
+      } catch {} // if the query reverts, epoch hasn't been finalized yet
 
       const tokens = await projectedAvailableTokens(
         contracts.tokenCapacitor,

--- a/client/pages/slates/create/grant.tsx
+++ b/client/pages/slates/create/grant.tsx
@@ -66,7 +66,6 @@ const FormSchema = yup.object().shape({
     .max(5000, 'Too Long!')
     .required('Required'),
   recommendation: yup.string().required('Required'),
-  proposals: yup.object().required('Required'),
   stake: yup.string().required('Required'),
 });
 
@@ -443,7 +442,10 @@ const CreateGrantSlate: StatelessPage<IProps> = ({ query, classes, router }) => 
                     .add(convertedToBaseUnits(val.tokensRequested))
                     .toString();
                 }, '0');
-                if (utils.bigNumberify(totalTokens).gt(availableTokens)) {
+                if (
+                  contracts.tokenCapacitor.functions.hasOwnProperty('projectedUnlockedBalance') &&
+                  utils.bigNumberify(totalTokens).gt(availableTokens)
+                ) {
                   setFieldError(
                     'proposals',
                     `token amount exceeds the projected available tokens (${baseToConvertedUnits(

--- a/client/pages/slates/create/grant.tsx
+++ b/client/pages/slates/create/grant.tsx
@@ -525,13 +525,17 @@ const CreateGrantSlate: StatelessPage<IProps> = ({ query, classes, router }) => 
                       </Label>
                       <ErrorMessage name="proposals" component="span" />
 
-                      <Text fontSize="0.75rem" color="grey">
-                        {`(There are currently `}
-                        <strong>{`${baseToConvertedUnits(
-                          availableTokens
-                        )} PAN tokens available`}</strong>
-                        {` for grant proposals at this time.)`}
-                      </Text>
+                      {contracts.tokenCapacitor.functions.hasOwnProperty(
+                        'projectedUnlockedBalance'
+                      ) && (
+                        <Text fontSize="0.75rem" color="grey">
+                          {`(There are currently `}
+                          <strong>{`${baseToConvertedUnits(
+                            availableTokens
+                          )} PAN tokens available`}</strong>
+                          {` for grant proposals at this time.)`}
+                        </Text>
+                      )}
 
                       <FlexContainer>
                         {proposals &&

--- a/client/pages/slates/create/index.tsx
+++ b/client/pages/slates/create/index.tsx
@@ -18,8 +18,9 @@ const CreateSlate: React.SFC = () => {
   React.useEffect(() => {
     if (isSlateSubmittable(currentBallot, category.toUpperCase())) {
       setCreateable(true);
+    } else {
+      setCreateable(false);
     }
-    setCreateable(false);
   }, [currentBallot.slateSubmissionDeadline, category]);
 
   return (

--- a/client/pages/slates/index.tsx
+++ b/client/pages/slates/index.tsx
@@ -50,8 +50,9 @@ const Slates: React.SFC = () => {
       isSlateSubmittable(currentBallot, 'GOVERNANCE')
     ) {
       setCreateable(true);
+    } else {
+      setCreateable(false);
     }
-    setCreateable(false);
   }, [currentBallot.slateSubmissionDeadline]);
 
   return (

--- a/client/utils/format.ts
+++ b/client/utils/format.ts
@@ -35,7 +35,11 @@ export function convertedToBaseUnits(converted: string, decimals: number = 18): 
 
 export function baseToConvertedUnits(base: BigNumberish, decimals: number = 18): string {
   // expects base: BigNumberish, throws on failure to convert
-  return utils.formatUnits(base, decimals).toString();
+  const converted = utils.formatUnits(base, decimals).toString();
+  const point = converted.indexOf('.');
+  const integer = converted.slice(0, point);
+  const fractional = converted.slice(point, point + 3);
+  return integer + fractional;
 }
 
 export function formatPanvalaUnits(base: BigNumberish): string {

--- a/client/utils/tokens.ts
+++ b/client/utils/tokens.ts
@@ -19,7 +19,7 @@ export async function projectedAvailableTokens(
   console.log('projected unlocked balance:', baseToConvertedUnits(pUnlockedBalance));
 
   let unredeemedTokens = '0';
-  if (winningSlate && winningSlate.category === 'GRANT' && winningSlate.proposals.length) {
+  if (winningSlate && winningSlate.proposals.length) {
     // filter out all the proposals that have been withdrawn already
     const unredeemedGrantsPromises = winningSlate.proposals.filter(async p => {
       const proposal = await tokenCapacitor.functions.proposals(p.id);

--- a/client/utils/tokens.ts
+++ b/client/utils/tokens.ts
@@ -1,0 +1,47 @@
+import { utils } from 'ethers';
+import { IProposal, ISlate } from '../interfaces';
+import { Gatekeeper, TokenCapacitor } from '../types';
+import { baseToConvertedUnits, convertedToBaseUnits } from './format';
+
+// Estimates the number of tokens that would be available given the current context
+export async function projectedAvailableTokens(
+  tokenCapacitor: TokenCapacitor,
+  gatekeeper: Gatekeeper,
+  epochNumber: number,
+  winningSlate?: ISlate
+) {
+  // project the unlocked token balance at the start of the next epoch
+  let pUnlockedBalance = utils.bigNumberify('0');
+  if (tokenCapacitor.functions.hasOwnProperty('projectedUnlockedBalance')) {
+    const nextEpochStart = await gatekeeper.functions.epochStart(epochNumber + 1);
+    pUnlockedBalance = await tokenCapacitor.functions.projectedUnlockedBalance(nextEpochStart);
+  }
+  console.log('projected unlocked balance:', baseToConvertedUnits(pUnlockedBalance));
+
+  let unredeemedTokens = '0';
+  if (winningSlate && winningSlate.category === 'GRANT' && winningSlate.proposals.length) {
+    // filter out all the proposals that have been withdrawn already
+    const unredeemedGrantsPromises = winningSlate.proposals.filter(async p => {
+      const proposal = await tokenCapacitor.functions.proposals(p.id);
+      return !proposal.withdrawn;
+    });
+    const unredeemedGrants: IProposal[] = await Promise.all(unredeemedGrantsPromises);
+
+    // add up all the unredeemed tokens
+    if (unredeemedGrants.length) {
+      unredeemedTokens = unredeemedGrants.reduce((acc: string, p: IProposal) => {
+        return utils
+          .bigNumberify(acc)
+          .add(convertedToBaseUnits(p.tokensRequested))
+          .toString();
+      }, '0');
+    }
+  }
+  console.log('unredeemed tokens:', baseToConvertedUnits(unredeemedTokens));
+
+  // subtract the unredeemed tokens from the projected
+  // total unlocked balance at the start of the next epoch
+  const projectedAvailableBalance = pUnlockedBalance.sub(unredeemedTokens);
+  console.log('projected available balance:', baseToConvertedUnits(projectedAvailableBalance));
+  return projectedAvailableBalance;
+}


### PR DESCRIPTION
this pr estimates the available tokens for grants for the current epoch

formula:

token capacitor's projected unlocked balance at the beginning of next epoch
**MINUS**
unredeemed tokens from last epoch's winning slate's proposals

this pr also prevents a user from creating a slate with a grant total which exceeds the estimated available tokens