### PR TITLE
Initialize the TokenCapacitor's unlocked balance

### DIFF
--- a/governance-contracts/conf/config.json
+++ b/governance-contracts/conf/config.json
@@ -12,7 +12,8 @@
   },
   "capacitor": {
     "charge": true,
-    "initialBalance": "50000000"
+    "initialBalance": "50000000",
+    "initialUnlockedBalance": "1000000"
   },
   "parameterStore": {
       "parameters": {

--- a/governance-contracts/contracts/TokenCapacitor.sol
+++ b/governance-contracts/contracts/TokenCapacitor.sol
@@ -69,7 +69,7 @@ contract TokenCapacitor {
     uint256 public lifetimeReleasedTokens;
 
     // IMPLEMENTATION
-    constructor(ParameterStore _parameters, IERC20 _token) public {
+    constructor(ParameterStore _parameters, IERC20 _token, uint256 initialUnlockedBalance) public {
         require(address(_parameters) != address(0), "Parameter store address cannot be zero");
         parameters = _parameters;
 
@@ -94,6 +94,7 @@ contract TokenCapacitor {
 
         scale = 10 ** PRECISION;
 
+        unlockedBalance = initialUnlockedBalance;
         lastLockedTime = now;
     }
 

--- a/governance-contracts/migrations/5_token_capacitor.js
+++ b/governance-contracts/migrations/5_token_capacitor.js
@@ -17,7 +17,13 @@ module.exports = async function(deployer, _, accounts) {
     ? await BasicToken.deployed()
     : await BasicToken.at(tokenInfo.address);
 
-  const capacitor = await deployer.deploy(TokenCapacitor, parameters.address, token.address);
+  const { charge, initialBalance, initialUnlockedBalance } = config;
+  const capacitor = await deployer.deploy(
+    TokenCapacitor,
+    parameters.address,
+    token.address,
+    initialUnlockedBalance,
+  );
 
   await parameters.setInitialValue(
     'tokenCapacitorAddress',
@@ -25,8 +31,6 @@ module.exports = async function(deployer, _, accounts) {
   );
 
   // Charge the capacitor
-  const { charge, initialBalance } = config;
-
   if (charge) {
     console.log(`Charging capacitor with ${initialBalance} tokens`);
 

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -148,6 +148,16 @@ function printDate(bn) {
 }
 
 /**
+ * Convert a date to a timestamp
+ * @param {string} date ISO-8601 date
+ * @returns number (unix timestamp in seconds)
+ */
+function dateToTimestamp(date) {
+  const dt = moment(date, moment.ISO_8601);
+  return dt.unix();
+}
+
+/**
  *@param {number} n
  */
 function range(n) {
@@ -238,7 +248,7 @@ async function newToken(params) {
 /**
  * Convenience function for creating a Gatekeeper
  * Deploys a Token and a ParameterStore they aren't passed in.
- * @param {*} options from, parameterStoreAddress, tokenAddress, init
+ * @param {*} options from, parameterStoreAddress, tokenAddress, startTime, init
  */
 async function newGatekeeper(options) {
   const {
@@ -301,7 +311,7 @@ async function newGatekeeper(options) {
 
 /**
  * Set up the Panvala contracts
- * @param {*} options from, parameterStoreAddress, tokenAddress, initialUnlockedBalance
+ * @param {*} options from, startTime, parameterStoreAddress, tokenAddress, initialUnlockedBalance
  */
 async function newPanvala(options) {
   const { from: creator, initialTokens, initialUnlockedBalance = toPanBase('0') } = options;
@@ -638,6 +648,7 @@ const utils = {
   newPanvala,
   epochTime,
   printDate,
+  dateToTimestamp,
   range,
   all,
   chain,

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -301,10 +301,10 @@ async function newGatekeeper(options) {
 
 /**
  * Set up the Panvala contracts
- * @param {*} options from, parameterStoreAddress, tokenAddress
+ * @param {*} options from, parameterStoreAddress, tokenAddress, initialUnlockedBalance
  */
 async function newPanvala(options) {
-  const { from: creator, initialTokens } = options;
+  const { from: creator, initialTokens, initialUnlockedBalance = toPanBase('0') } = options;
   assert(typeof initialTokens === 'undefined', 'should not have key initialTokens');
 
   const gatekeeper = await newGatekeeper({ ...options, init: false });
@@ -312,7 +312,12 @@ async function newPanvala(options) {
   const parameters = await ParameterStore.at(parametersAddress);
   const tokenAddress = await gatekeeper.token();
   const token = await BasicToken.at(tokenAddress);
-  const capacitor = await TokenCapacitor.new(parameters.address, token.address, { from: creator });
+  const capacitor = await TokenCapacitor.new(
+    parameters.address,
+    token.address,
+    initialUnlockedBalance,
+    { from: creator },
+  );
 
   await parameters.setInitialValue(
     'tokenCapacitorAddress',


### PR DESCRIPTION
Allow the TokenCapacitor to be initialized with an unlocked balance, so that tokens can be claimed earlier. No balance updates can happen until its actual token balance is at least the unlocked balance.

* Add initialUnlockedBalance to constructor and migration
* Add tests