### PR TITLE
use block.timestamp for dates

### DIFF
--- a/client/components/MainProvider.tsx
+++ b/client/components/MainProvider.tsx
@@ -90,10 +90,12 @@ const MainProvider: React.FC<any> = (props: any) => {
         GRANT: 0,
         GOVERNANCE: 0,
       },
+      bts: 0,
     },
   });
   const {
     contracts: { gatekeeper, tokenCapacitor, parameterStore },
+    ethProvider,
   } = React.useContext(EthereumContext);
 
   // init slates and proposals from api
@@ -125,6 +127,9 @@ const MainProvider: React.FC<any> = (props: any) => {
     )).toNumber();
     currentBallot.epochNumber = epochNumber.toNumber();
 
+    const blockNumber = await ethProvider.getBlockNumber();
+    const block = await ethProvider.getBlock(blockNumber);
+    currentBallot.bts = block.timestamp;
     console.log('currentBallot:', currentBallot);
     return dispatch({ type: 'ballot', currentBallot });
   }

--- a/client/components/SlateSidebar.tsx
+++ b/client/components/SlateSidebar.tsx
@@ -10,7 +10,7 @@ import SectionLabel from './SectionLabel';
 import { Separator } from './Separator';
 import { formatPanvalaUnits, splitAddressHumanReadable } from '../utils/format';
 import { convertEVMSlateStatus, statuses, slateSubmissionDeadline } from '../utils/status';
-import { timestamp, tsToDeadline } from '../utils/datetime';
+import { tsToDeadline } from '../utils/datetime';
 import { ISlate, IBallotDates } from '../interfaces';
 import { colors } from '../styles';
 
@@ -55,8 +55,7 @@ const SlateSidebar = ({ slate, requiredStake, currentBallot }: IStakeSidebarProp
 
   // Calculate the extended deadline from now and the start of the commit period,
   // assuming you were to stake right now
-  const now = timestamp();
-  const newDeadline = slateSubmissionDeadline(currentBallot.votingOpenDate, now);
+  const newDeadline = slateSubmissionDeadline(currentBallot.votingOpenDate, currentBallot.bts);
 
   return (
     <>

--- a/client/interfaces/voting.ts
+++ b/client/interfaces/voting.ts
@@ -29,4 +29,5 @@ export interface IBallotDates {
     [key: string]: number;
   };
   epochNumber: number;
+  bts: number;
 }

--- a/client/utils/datetime.ts
+++ b/client/utils/datetime.ts
@@ -15,7 +15,8 @@ export const tsToDeadline = (unixTimestamp: number, customTimezone?: string): st
   return deadline.tz(customTimezone).format(fmt);
 };
 
-export const dateHasPassed = (uts: number) => isAfter(new Date(), new Date(uts * 1000));
+export const dateHasPassed = (uts: number, blockTimestamp: number) =>
+  isAfter(new Date(blockTimestamp * 1000), new Date(uts * 1000));
 
 export const timestamp = (): number => {
   return Math.floor(new Date().getTime() / 1000);

--- a/client/utils/status.ts
+++ b/client/utils/status.ts
@@ -42,7 +42,9 @@ export function isPendingVote(status: string) {
   return status === statuses.PENDING_VOTE;
 }
 export function isCurrentBallot(ballot: IBallotDates) {
-  return dateHasPassed(ballot.startDate) && !dateHasPassed(ballot.finalityDate);
+  return (
+    dateHasPassed(ballot.startDate, ballot.bts) && !dateHasPassed(ballot.finalityDate, ballot.bts)
+  );
 }
 // weeks 1 - [5.5]
 export function isSlateSubmittable(ballot: IBallotDates, category: string): boolean {
@@ -53,19 +55,27 @@ export function isSlateSubmittable(ballot: IBallotDates, category: string): bool
 }
 // weeks 1 - 11
 export function isPreVoting(ballot: IBallotDates) {
-  return dateHasPassed(ballot.startDate) && !dateHasPassed(ballot.votingOpenDate);
+  return (
+    dateHasPassed(ballot.startDate, ballot.bts) && !dateHasPassed(ballot.votingOpenDate, ballot.bts)
+  );
 }
 // week 12
 export function isBallotOpen(ballot: IBallotDates) {
-  return !dateHasPassed(ballot.votingCloseDate) && dateHasPassed(ballot.votingOpenDate);
+  return (
+    !dateHasPassed(ballot.votingCloseDate, ballot.bts) &&
+    dateHasPassed(ballot.votingOpenDate, ballot.bts)
+  );
 }
 // week 13
 export function isBallotClosed(ballot: IBallotDates) {
-  return dateHasPassed(ballot.votingCloseDate) && !dateHasPassed(ballot.finalityDate);
+  return (
+    dateHasPassed(ballot.votingCloseDate, ballot.bts) &&
+    !dateHasPassed(ballot.finalityDate, ballot.bts)
+  );
 }
 // week 14
 export function isBallotFinalized(ballot: IBallotDates) {
-  return dateHasPassed(ballot.finalityDate);
+  return dateHasPassed(ballot.finalityDate, ballot.bts);
 }
 
 export function getPrefixAndDeadline(


### PR DESCRIPTION
this pr includes an experimental commit which considers the latest `block.timestamp` as "now". this is useful when discovering locked/unlocked/projected balances, and the additional changes made to the `time-travel.js` script in #117 can be used in conjunction with the changes in this pr to see differences in locked/unlocked/projected token balances.