### PR TITLE
card visibility fixes

### DIFF
--- a/api/utils/slates.js
+++ b/api/utils/slates.js
@@ -76,6 +76,12 @@ async function getAllSlates() {
       ) {
         incumbent = true;
       }
+
+      // manually reject slates that are old and not accepted
+      if (BN(slate.epochNumber).lt(currentEpoch) && slate.status !== 3) {
+        slate.status = 2;
+      }
+
       console.log('slate:', slate);
       return getSlateWithMetadata(slateID, slate, decoded, incumbent, requiredStake);
     },

--- a/api/utils/slates.js
+++ b/api/utils/slates.js
@@ -77,6 +77,11 @@ async function getAllSlates() {
         incumbent = true;
       }
 
+      // manually reject slates that are old and not accepted
+      if (BN(slate.epochNumber).lt(currentEpoch) && slate.status !== 3) {
+        slate.status = 2;
+      }
+
       console.log('slate:', slate);
       return getSlateWithMetadata(slateID, slate, decoded, incumbent, requiredStake);
     },

--- a/api/utils/slates.js
+++ b/api/utils/slates.js
@@ -77,11 +77,6 @@ async function getAllSlates() {
         incumbent = true;
       }
 
-      // manually reject slates that are old and not accepted
-      if (BN(slate.epochNumber).lt(currentEpoch) && slate.status !== 3) {
-        slate.status = 2;
-      }
-
       console.log('slate:', slate);
       return getSlateWithMetadata(slateID, slate, decoded, incumbent, requiredStake);
     },

--- a/client/components/MainProvider.tsx
+++ b/client/components/MainProvider.tsx
@@ -84,6 +84,12 @@ const MainProvider: React.FC<any> = (props: any) => {
       votingOpenDate: 0,
       votingCloseDate: 0,
       finalityDate: 0,
+      epochNumber: 0,
+      initialSlateSubmissionDeadline: 0,
+      slateSubmissionDeadline: {
+        GRANT: 0,
+        GOVERNANCE: 0,
+      },
     },
   });
   const {

--- a/client/components/MainProvider.tsx
+++ b/client/components/MainProvider.tsx
@@ -7,10 +7,8 @@ import isEmpty from 'lodash/isEmpty';
 import { EthereumContext } from './EthereumProvider';
 import { IProposal, ISlate, IBallotDates } from '../interfaces';
 import { getAllProposals, getAllSlates } from '../utils/api';
-import { baseToConvertedUnits, BN } from '../utils/format';
+import { baseToConvertedUnits } from '../utils/format';
 import { ballotDates } from '../utils/voting';
-import { currentBallot } from './stories/data';
-import { SlateStatus } from '../utils/status';
 
 export interface IMainContext {
   slates: ISlate[];
@@ -42,16 +40,10 @@ async function handleGetAllProposals() {
   return [];
 }
 
-async function handleGetAllSlates(currentEpoch) {
+async function handleGetAllSlates() {
   const slates: ISlate[] | AxiosResponse = await getAllSlates();
   if (Array.isArray(slates)) {
-    return slates.map(slate => {
-      // manually reject slates that are old and not accepted
-      if (BN(slate.epochNumber).lt(currentEpoch) && slate.status !== SlateStatus.Accepted) {
-        slate.status = 2;
-      }
-      return slate;
-    });
+    return slates;
   }
 
   return [];
@@ -156,7 +148,7 @@ const MainProvider: React.FC<any> = (props: any) => {
   }
 
   async function refreshSlates() {
-    const slates: ISlate[] = await handleGetAllSlates(currentBallot.epochNumber);
+    const slates: ISlate[] = await handleGetAllSlates();
     const slatesByID = keyBy(slates, 'id');
 
     console.log('slates:', slates);

--- a/client/pages/slates/index.tsx
+++ b/client/pages/slates/index.tsx
@@ -29,7 +29,7 @@ const Slates: React.SFC = () => {
   }
 
   React.useEffect(() => {
-    if (slates.length > 0 && currentBallot.epochNumber) {
+    if (slates.length > 0) {
       if (visibilityFilter === 'CURRENT') {
         setVisibleSlates(
           slates.filter((s: ISlate) => BN(s.epochNumber).eq(currentBallot.epochNumber))

--- a/client/pages/slates/index.tsx
+++ b/client/pages/slates/index.tsx
@@ -21,7 +21,7 @@ const VisibilityFilterContainer = styled.div`
 const Slates: React.SFC = () => {
   const { slates, currentBallot }: IMainContext = React.useContext(MainContext);
   const [visibleSlates, setVisibleSlates] = React.useState(slates);
-  const [visibilityFilter, setVisibilityFilter] = React.useState('ALL');
+  const [visibilityFilter, setVisibilityFilter] = React.useState('CURRENT');
   const [createable, setCreateable] = React.useState(false);
 
   function handleSelectVisibilityFilter(filter: string) {
@@ -29,10 +29,8 @@ const Slates: React.SFC = () => {
   }
 
   React.useEffect(() => {
-    if (slates.length > 0) {
-      if (visibilityFilter === 'ALL') {
-        setVisibleSlates(slates);
-      } else if (visibilityFilter === 'CURRENT') {
+    if (slates.length > 0 && currentBallot.epochNumber) {
+      if (visibilityFilter === 'CURRENT') {
         setVisibleSlates(
           slates.filter((s: ISlate) => BN(s.epochNumber).eq(currentBallot.epochNumber))
         );
@@ -42,7 +40,7 @@ const Slates: React.SFC = () => {
         );
       }
     }
-  }, [slates, visibilityFilter]);
+  }, [slates, visibilityFilter, currentBallot.epochNumber]);
 
   React.useEffect(() => {
     if (
@@ -69,13 +67,6 @@ const Slates: React.SFC = () => {
       </Flex>
 
       <VisibilityFilterContainer>
-        <Button
-          onClick={() => handleSelectVisibilityFilter('ALL')}
-          active={visibilityFilter === 'ALL'}
-        >
-          {'All'}
-        </Button>
-
         <Button
           onClick={() => handleSelectVisibilityFilter('CURRENT')}
           active={visibilityFilter === 'CURRENT'}


### PR DESCRIPTION
- manually reject old, non-accepted slates
- rm `ALL` visibility filter for `/slates` route
- default to `CURRENT`
- filter ballot slates (current epoch only)