### PR TITLE
Add route to check liveness of the frontend

### DIFF
--- a/charts/panvala-frontend/templates/deployment.yaml
+++ b/charts/panvala-frontend/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
                   key: tokenCapacitor
           livenessProbe:
             httpGet:
-              path: /
+              path: /liveness
               port: http
             initialDelaySeconds: 10
             periodSeconds: 15

--- a/client/pages/Liveness.tsx
+++ b/client/pages/Liveness.tsx
@@ -1,0 +1,13 @@
+import { StatelessPage } from '../interfaces';
+
+const Liveness: StatelessPage<any> = () => {
+  return (
+    <div>This is the Panvala frontend</div>
+  );
+};
+
+Liveness.getInitialProps = async ({ asPath }) => {
+    return { asPath };
+};
+
+export default Liveness;

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -61,6 +61,12 @@ export default class MyApp extends App<IProps, IState> {
       return <ErrorPage statusCode={errorCode} />;
     }
 
+    // If this is a liveness check, do not render the full context. We just want to check that
+    // the application is running.
+    if (typeof pageProps.asPath !== 'undefined' && pageProps.asPath.startsWith('/liveness')) {
+      return <Component {...pageProps} />;
+    }
+
     return (
       <Container>
         <EthereumProvider>

--- a/client/server.js
+++ b/client/server.js
@@ -85,6 +85,15 @@ app.prepare().then(() => {
   });
 
   // ----------------------------------------------
+  // LIVENESS and READINESS
+  // ----------------------------------------------
+
+  // Use this to check if the application is alive
+  server.get('/liveness', (req, res) => {
+    return app.render(req, res, '/Liveness');
+  });
+
+  // ----------------------------------------------
   // HOUSEKEEPING
   // ----------------------------------------------
 


### PR DESCRIPTION
Before, the liveness check was hitting the index, which fetches all the state (i.e. slates) and is quite heavy. Instead, add a liveness check that only checks that the application can receive a request and respond. The readiness check still hits the index so that we can detect configuration errors.

* Add a `/liveness` route to the frontend
* Update the deployment to use the new endpoint