### PR TITLE
Minor fixes for ballot reveal

### DIFF
--- a/api/scripts/reveal-ballots.js
+++ b/api/scripts/reveal-ballots.js
@@ -34,6 +34,25 @@ function encode(choices) {
   return voting.encodeBallot(resources, firstChoices, secondChoices);
 }
 
+async function revealSingle(gatekeeper, ballot) {
+  const { voterAddress, salt, VoteChoices, epochNumber } = ballot;
+  try {
+    const tx = await gatekeeper.functions.revealBallot(
+      epochNumber,
+      voterAddress,
+      VoteChoices.map(choice => choice.resource),
+      VoteChoices.map(choice => choice.firstChoice),
+      VoteChoices.map(choice => choice.secondChoice),
+      salt,
+    );
+    console.log(tx);
+    const receipt = await tx.wait();
+    console.log(receipt);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
 function parseArgs() {
   // node reveal-ballots.js
   if (process.argv.length !== 2) {
@@ -57,7 +76,8 @@ async function run() {
 
   // read ballots from the database
   const ballots = await getBallots(epochNumber);
-  console.log('ballots:', ballots);
+  console.log(`Found ${ballots.length} ballot(s)`);
+  // console.log('ballots:', ballots);
 
   if (ballots.length === 0) {
     console.log(`No ballots for batch ${epochNumber}`);
@@ -65,22 +85,27 @@ async function run() {
   }
 
   // Filter out the ones that have already been revealed
-  const ballotPromises = ballots.map(b => {
+  const ballotPromises = ballots.map(async b => {
     const _ballot = b.get({ plain: true });
+    const didCommit = await gatekeeper.functions.didCommit(epochNumber, _ballot.voterAddress);
     return gatekeeper.functions.didReveal(epochNumber, _ballot.voterAddress).then(didReveal => {
       // console.log(didReveal, _ballot);
-      return { ..._ballot, didReveal };
+      return { ..._ballot, didReveal, didCommit };
     });
   });
 
   const enriched = await Promise.all(ballotPromises);
   console.log('ENRICHED', enriched);
 
-  const toReveal = enriched.filter(e => e.didReveal === false);
+  // const notCommitted = enriched.filter(e => e.didCommit === false);
+  const toReveal = enriched.filter(e => e.didReveal === false).filter(e => e.didCommit);
   console.log('TO REVEAL', toReveal);
 
   if (toReveal.length === 0) {
     console.log(`All ballots already revealed for batch ${epochNumber}`);
+    // if (notCommitted.length > 0) {
+    //   console.warn(`Some ballots have not been committed: ${JSON.stringify(notCommitted)}`);
+    // }
     process.exit(0);
   }
 
@@ -93,6 +118,11 @@ async function run() {
 
   // Prepare data
   console.log(`Preparing data for ${toReveal.length} ballot(s) ...`);
+
+  // Backup if the batched tx is failing: reveal a single ballot and exit
+  // await revealSingle(gatekeeper, toReveal[0]);
+  // process.exit(0);
+
   toReveal.forEach(ballot => {
     const data = ballot;
     console.log('did reveal? ', data.didReveal);
@@ -120,6 +150,8 @@ async function run() {
         salts
       );
       console.log(tx);
+      const receipt = await tx.wait();
+      console.log(receipt);
 
       console.log('DONE');
       process.exit(0);

--- a/api/scripts/reveal-ballots.js
+++ b/api/scripts/reveal-ballots.js
@@ -97,15 +97,16 @@ async function run() {
   const enriched = await Promise.all(ballotPromises);
   console.log('ENRICHED', enriched);
 
-  // const notCommitted = enriched.filter(e => e.didCommit === false);
-  const toReveal = enriched.filter(e => e.didReveal === false).filter(e => e.didCommit);
+  const notCommitted = enriched.filter(e => e.didCommit === false);
+  const toReveal = enriched.filter(e => e.didCommit && e.didReveal === false);
   console.log('TO REVEAL', toReveal);
+
+  if (notCommitted.length > 0) {
+    console.warn(`Some ballots have not been committed: ${JSON.stringify(notCommitted)}`);
+  }
 
   if (toReveal.length === 0) {
     console.log(`All ballots already revealed for batch ${epochNumber}`);
-    // if (notCommitted.length > 0) {
-    //   console.warn(`Some ballots have not been committed: ${JSON.stringify(notCommitted)}`);
-    // }
     process.exit(0);
   }
 


### PR DESCRIPTION
Filter out ballots that have not been committed, as they cause the entire `revealManyBallots()` tx to fail.