### PR TITLE
Minor audit issues

### DIFF
--- a/governance-contracts/contracts/BasicToken.sol
+++ b/governance-contracts/contracts/BasicToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.10;
 
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";

--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.10;
 pragma experimental ABIEncoderV2;
 
 import "./ParameterStore.sol";

--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -554,6 +554,10 @@ contract Gatekeeper {
         uint[] memory _salts
     ) public {
         uint numBallots = _voters.length;
+        require(
+            _salts.length == _voters.length && _ballots.length == _voters.length,
+            "Inputs must have the same length"
+        );
 
         for (uint i = 0; i < numBallots; i++) {
             // extract resources, firstChoices, secondChoices from the ballot

--- a/governance-contracts/contracts/ParameterStore.sol
+++ b/governance-contracts/contracts/ParameterStore.sol
@@ -37,10 +37,8 @@ contract ParameterStore {
         bool executed;
     }
 
-    mapping(uint => Proposal) public proposals;
-
-    // The total number of proposals
-    uint public proposalCount;
+    // All submitted proposals
+    Proposal[] public proposals;
 
     // IMPLEMENTATION
     /**
@@ -146,9 +144,8 @@ contract ParameterStore {
         // proposalID.
         uint requestID = gatekeeper.requestPermission(metadataHash);
         p.requestID = requestID;
-        uint proposalID = proposalCount;
-        proposals[proposalID] = p;
-        proposalCount = proposalCount.add(1);
+        uint proposalID = proposalCount();
+        proposals.push(p);
 
         emit ProposalCreated(proposalID, msg.sender, requestID, key, value, metadataHash);
         return proposalID;
@@ -182,7 +179,7 @@ contract ParameterStore {
      @param proposalID The proposal
      */
     function setValue(uint256 proposalID) public returns(bool) {
-        require(proposalID < proposalCount, "Invalid proposalID");
+        require(proposalID < proposalCount(), "Invalid proposalID");
 
         Proposal memory p = proposals[proposalID];
         Gatekeeper gatekeeper = Gatekeeper(p.gatekeeper);
@@ -196,6 +193,10 @@ contract ParameterStore {
 
         emit ProposalAccepted(proposalID, p.key, p.value);
         return true;
+    }
+
+    function proposalCount() public view returns(uint256) {
+        return proposals.length;
     }
 
     function _gatekeeper() private view returns(Gatekeeper) {

--- a/governance-contracts/contracts/ParameterStore.sol
+++ b/governance-contracts/contracts/ParameterStore.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.10;
 pragma experimental ABIEncoderV2;
 
 import "./Gatekeeper.sol";

--- a/governance-contracts/contracts/TokenCapacitor.sol
+++ b/governance-contracts/contracts/TokenCapacitor.sol
@@ -48,8 +48,7 @@ contract TokenCapacitor {
     Proposal[] public proposals;
 
     // Token decay table
-    uint256 constant PRECISION = 12;
-    uint256 public scale;
+    uint256 public constant SCALE = 10 ** 12;
     uint256[12] decayMultipliers;
 
     // Balances
@@ -88,8 +87,6 @@ contract TokenCapacitor {
         decayMultipliers[9] = 783688183013;
         decayMultipliers[10] = 614167168195;
         decayMultipliers[11] = 377201310488;
-
-        scale = 10 ** PRECISION;
 
         unlockedBalance = initialUnlockedBalance;
         lastLockedTime = now;
@@ -227,7 +224,7 @@ contract TokenCapacitor {
         // Based on the elapsed time (in days), calculate the decay factor
         uint256 decayFactor = calculateDecay(elapsedTime.div(86400));
 
-        return lastLockedBalance.mul(decayFactor).div(scale);
+        return lastLockedBalance.mul(decayFactor).div(SCALE);
     }
 
     /**
@@ -236,7 +233,7 @@ contract TokenCapacitor {
     function calculateDecay(uint256 _days) public view returns(uint256) {
         require(_days <= (2 ** decayMultipliers.length) - 1, "Time interval too large");
 
-        uint256 decay = scale;
+        uint256 decay = SCALE;
         uint256 d = _days;
 
         for (uint256 i = 0; i < decayMultipliers.length; i++) {
@@ -245,7 +242,7 @@ contract TokenCapacitor {
 
            if (remainder == 1) {
                 uint256 multiplier = decayMultipliers[i];
-                decay = decay.mul(multiplier).div(scale);
+                decay = decay.mul(multiplier).div(SCALE);
            } else if (quotient == 0) {
                // Exit early if both quotient and remainder are zero
                break;

--- a/governance-contracts/contracts/TokenCapacitor.sol
+++ b/governance-contracts/contracts/TokenCapacitor.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.10;
 pragma experimental ABIEncoderV2;
 
 import "./Gatekeeper.sol";

--- a/governance-contracts/contracts/TokenCapacitor.sol
+++ b/governance-contracts/contracts/TokenCapacitor.sol
@@ -44,11 +44,8 @@ contract TokenCapacitor {
         bool withdrawn;
     }
 
-    // The proposals created for the TokenCapacitor. Maps requestIDs to proposals.
-    mapping(uint => Proposal) public proposals;
-
-    // The total number of proposals
-    uint public proposalCount;
+    // The proposals created for the TokenCapacitor.
+    Proposal[] public proposals;
 
     // Token decay table
     uint256 constant PRECISION = 12;
@@ -126,9 +123,8 @@ contract TokenCapacitor {
         // proposalID.
         uint requestID = gatekeeper.requestPermission(metadataHash);
         p.requestID = requestID;
-        uint proposalID = proposalCount;
-        proposals[proposalID] = p;
-        proposalCount = proposalCount.add(1);
+        uint proposalID = proposalCount();
+        proposals.push(p);
 
         emit ProposalCreated(proposalID, msg.sender, requestID, to, tokens, metadataHash);
         return proposalID;
@@ -162,7 +158,7 @@ contract TokenCapacitor {
     @param proposalID The proposal
     */
     function withdrawTokens(uint proposalID) public returns(bool) {
-        require(proposalID < proposalCount, "Invalid proposalID");
+        require(proposalID < proposalCount(), "Invalid proposalID");
 
         Proposal memory p = proposals[proposalID];
         Gatekeeper gatekeeper = Gatekeeper(p.gatekeeper);
@@ -292,5 +288,9 @@ contract TokenCapacitor {
      */
     function updateBalances() public {
         updateBalancesUntil(now);
+    }
+
+    function proposalCount() public view returns(uint256) {
+        return proposals.length;
     }
 }

--- a/governance-contracts/test/gatekeeper.js
+++ b/governance-contracts/test/gatekeeper.js
@@ -2042,6 +2042,83 @@ contract('Gatekeeper', (accounts) => {
       didReveal.forEach(revealed => assert.strictEqual(revealed, true, 'Voter should have revealed'));
     });
 
+    describe('input lengths', () => {
+      let voters;
+      let ballots;
+      let salts;
+
+      beforeEach(async () => {
+        // Advance to commit period
+        await increaseTime(timing.VOTING_PERIOD_START);
+
+        const [aliceSalt, bobSalt, carolSalt] = ['1234', '5678', '9012'];
+
+        const aliceReveal = await commitBallot(gatekeeper, alice, [[GRANT, 0, 1], [GOVERNANCE, 2, 3]], '1000', aliceSalt);
+        const bobReveal = await commitBallot(gatekeeper, bob, [[GRANT, 0, 1], [GOVERNANCE, 2, 3]], '1000', bobSalt);
+        const carolReveal = await commitBallot(gatekeeper, carol, [[GRANT, 1, 0], [GOVERNANCE, 2, 3]], '1000', carolSalt);
+
+        // Prepare data
+        voters = [alice, bob, carol];
+        ballots = [aliceReveal, bobReveal, carolReveal].map(_reveal => utils.encodeBallot(
+          _reveal.resources,
+          _reveal.firstChoices,
+          _reveal.secondChoices,
+        ));
+        salts = [aliceSalt, bobSalt, carolSalt];
+
+        // Advance to reveal period
+        await increaseTime(timing.COMMIT_PERIOD_LENGTH);
+      });
+
+      it('should revert if the length of salts is short', async () => {
+        try {
+          await gatekeeper.revealManyBallots(
+            epochNumber,
+            voters,
+            ballots,
+            salts.slice(0, 1),
+          );
+        } catch (error) {
+          expectRevert(error);
+          expectErrorLike(error, 'same length');
+          return;
+        }
+        assert.fail('Allowed revealManyBallots with short salts');
+      });
+
+      it('should revert if the length of voters is short', async () => {
+        try {
+          await gatekeeper.revealManyBallots(
+            epochNumber,
+            voters.slice(0, 1),
+            ballots,
+            salts,
+          );
+        } catch (error) {
+          expectRevert(error);
+          expectErrorLike(error, 'same length');
+          return;
+        }
+        assert.fail('Allowed revealManyBallots with short voters');
+      });
+
+      it('should revert if the length of ballots is short', async () => {
+        try {
+          await gatekeeper.revealManyBallots(
+            epochNumber,
+            voters,
+            ballots.slice(0, 1),
+            salts,
+          );
+        } catch (error) {
+          expectRevert(error);
+          expectErrorLike(error, 'same length');
+          return;
+        }
+        assert.fail('Allowed revealManyBallots with short ballots');
+      });
+    });
+
     afterEach(async () => utils.evm.revert(snapshotID));
   });
 

--- a/governance-contracts/test/integration.js
+++ b/governance-contracts/test/integration.js
@@ -59,7 +59,7 @@ contract('integration', (accounts) => {
       await utils.chargeCapacitor(capacitor, 50e6, token, { from: creator });
 
       GRANT = await getResource(gatekeeper, 'GRANT');
-      scale = await capacitor.scale();
+      scale = await capacitor.SCALE();
 
       // Make sure the recommender has tokens
       const recommenderTokens = toPanBase('50000000');

--- a/governance-contracts/test/tokenCapacitor.js
+++ b/governance-contracts/test/tokenCapacitor.js
@@ -775,7 +775,7 @@ contract('TokenCapacitor', (accounts) => {
       before(async () => {
         ({ token, capacitor } = await utils.newPanvala({ from: creator }));
         await utils.chargeCapacitor(capacitor, supply, token, { from: creator });
-        scale = await capacitor.scale();
+        scale = await capacitor.SCALE();
       });
 
       beforeEach(async () => {
@@ -926,7 +926,7 @@ contract('TokenCapacitor', (accounts) => {
         ({ token, capacitor } = await utils.newPanvala({ from: creator }));
         await token.transfer(capacitor.address, supply, { from: creator });
         await capacitor.updateBalances({ from: creator });
-        scale = await capacitor.scale();
+        scale = await capacitor.SCALE();
       });
 
       const tests = [
@@ -1006,7 +1006,7 @@ contract('TokenCapacitor', (accounts) => {
         await token.transfer(capacitor.address, supply, { from: creator });
         await capacitor.updateBalances();
 
-        scale = await capacitor.scale();
+        scale = await capacitor.SCALE();
       });
 
       const tests = [

--- a/governance-contracts/truffle-config.js
+++ b/governance-contracts/truffle-config.js
@@ -134,7 +134,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: '0.5.1',    // Fetch exact version from solc-bin (default: truffle's version)
+      version: '0.5.10',    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       settings: {          // See the solidity docs for advice about optimization and evmVersion
         optimizer: {


### PR DESCRIPTION
Address some relatively straight-forward audit issues:

* Pin Solidity version to 0.5.10 (7.23)
* Use arrays instead of mappings for proposals (7.24 - partial)
* Make `TokenCapacitor.scale` constant `SCALE` and remove `PRECISION` (7.22)
* Ensure equal input lengths to `revealManyBallots()` (7.14)