### PR TITLE
Use arrays for slates and requests in Gatekeeper

### DIFF
--- a/governance-contracts/contracts/BasicToken.sol
+++ b/governance-contracts/contracts/BasicToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.10;
 
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";

--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -81,11 +81,8 @@ contract Gatekeeper {
         uint expirationTime;
     }
 
-    // The requests made to the Gatekeeper. Maps requestID -> Request.
-    mapping(uint => Request) public requests;
-
-    // The total number of requests created
-    uint public requestCount;
+    // The requests made to the Gatekeeper.
+    Request[] public requests;
 
     // Voting
     enum SlateStatus {
@@ -108,11 +105,9 @@ contract Gatekeeper {
         uint256 epochNumber;
         address resource;
     }
-    // The slates created by the Gatekeeper. Maps slateID -> Slate.
-    mapping(uint => Slate) public slates;
 
-    // The total number of slates created
-    uint public slateCount;
+    // The slates created by the Gatekeeper.
+    Slate[] public slates;
 
     // The number of tokens each account has available for voting
     mapping(address => uint) public voteTokenBalance;
@@ -248,14 +243,13 @@ contract Gatekeeper {
         });
 
         // Record slate and return its ID
-        uint slateID = slateCount;
-        slates[slateID] = s;
-        slateCount = slateCount.add(1);
+        uint slateID = slateCount();
+        slates.push(s);
 
         // Set up the requests
         for (uint i = 0; i < requestIDs.length; i++) {
             uint requestID = requestIDs[i];
-            require(requestID < requestCount, "Invalid requestID");
+            require(requestID < requestCount(), "Invalid requestID");
 
             // Every request's resource must match the one passed in
             require(requests[requestID].resource == resource, "Resource does not match");
@@ -285,7 +279,7 @@ contract Gatekeeper {
     @param slateID The slate to stake on
      */
     function stakeTokens(uint slateID) public returns(bool) {
-        require(slateID < slateCount, "No slate exists with that slateID");
+        require(slateID < slateCount(), "No slate exists with that slateID");
         require(slates[slateID].status == SlateStatus.Unstaked, "Slate has already been staked");
 
         address staker = msg.sender;
@@ -332,7 +326,7 @@ contract Gatekeeper {
     @param slateID The slate to withdraw the stake from
      */
     function withdrawStake(uint slateID) public returns(bool) {
-        require(slateID < slateCount, "No slate exists with that slateID");
+        require(slateID < slateCount(), "No slate exists with that slateID");
 
         // get slate
         Slate memory slate = slates[slateID];
@@ -930,9 +924,8 @@ contract Gatekeeper {
         });
 
         // Record request and return its ID
-        uint requestID = requestCount;
-        requests[requestID] = r;
-        requestCount = requestCount.add(1);
+        uint requestID = requestCount();
+        requests.push(r);
 
         emit PermissionRequested(resource, requestID, metadataHash);
         return requestID;
@@ -970,6 +963,14 @@ contract Gatekeeper {
 
 
     // MISCELLANEOUS GETTERS
+    function slateCount() public view returns(uint256) {
+        return slates.length;
+    }
+
+    function requestCount() public view returns (uint256) {
+        return requests.length;
+    }
+
     /**
     @dev Return the slate submission deadline for the given resource
     @param epochNumber The epoch

--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.10;
 pragma experimental ABIEncoderV2;
 
 import "./ParameterStore.sol";

--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -554,6 +554,10 @@ contract Gatekeeper {
         uint[] memory _salts
     ) public {
         uint numBallots = _voters.length;
+        require(
+            _salts.length == _voters.length && _ballots.length == _voters.length,
+            "Inputs must have the same length"
+        );
 
         for (uint i = 0; i < numBallots; i++) {
             // extract resources, firstChoices, secondChoices from the ballot

--- a/governance-contracts/contracts/ParameterStore.sol
+++ b/governance-contracts/contracts/ParameterStore.sol
@@ -37,10 +37,8 @@ contract ParameterStore {
         bool executed;
     }
 
-    mapping(uint => Proposal) public proposals;
-
-    // The total number of proposals
-    uint public proposalCount;
+    // All submitted proposals
+    Proposal[] public proposals;
 
     // IMPLEMENTATION
     /**
@@ -146,9 +144,8 @@ contract ParameterStore {
         // proposalID.
         uint requestID = gatekeeper.requestPermission(metadataHash);
         p.requestID = requestID;
-        uint proposalID = proposalCount;
-        proposals[proposalID] = p;
-        proposalCount = proposalCount.add(1);
+        uint proposalID = proposalCount();
+        proposals.push(p);
 
         emit ProposalCreated(proposalID, msg.sender, requestID, key, value, metadataHash);
         return proposalID;
@@ -182,7 +179,7 @@ contract ParameterStore {
      @param proposalID The proposal
      */
     function setValue(uint256 proposalID) public returns(bool) {
-        require(proposalID < proposalCount, "Invalid proposalID");
+        require(proposalID < proposalCount(), "Invalid proposalID");
 
         Proposal memory p = proposals[proposalID];
         Gatekeeper gatekeeper = Gatekeeper(p.gatekeeper);
@@ -196,6 +193,10 @@ contract ParameterStore {
 
         emit ProposalAccepted(proposalID, p.key, p.value);
         return true;
+    }
+
+    function proposalCount() public view returns(uint256) {
+        return proposals.length;
     }
 
     function _gatekeeper() private view returns(Gatekeeper) {

--- a/governance-contracts/contracts/ParameterStore.sol
+++ b/governance-contracts/contracts/ParameterStore.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.10;
 pragma experimental ABIEncoderV2;
 
 import "./Gatekeeper.sol";

--- a/governance-contracts/contracts/ParameterStore.sol
+++ b/governance-contracts/contracts/ParameterStore.sol
@@ -120,16 +120,7 @@ contract ParameterStore {
         set(_name, _value);
     }
 
-    /**
-     @dev Create a proposal to set a value.
-     @param key The key to set
-     @param value The value to set
-     @param metadataHash A reference to metadata describing the proposal
-     */
-    function createProposal(string memory key, bytes32 value, bytes memory metadataHash) public returns(uint256) {
-        require(metadataHash.length > 0, "metadataHash cannot be empty");
-
-        Gatekeeper gatekeeper = _gatekeeper();
+    function _createProposal(Gatekeeper gatekeeper, string memory key, bytes32 value, bytes memory metadataHash) internal returns(uint256) {
         Proposal memory p = Proposal({
             gatekeeper: address(gatekeeper),
             requestID: 0,
@@ -152,24 +143,40 @@ contract ParameterStore {
     }
 
     /**
+     @dev Create a proposal to set a value.
+     @param key The key to set
+     @param value The value to set
+     @param metadataHash A reference to metadata describing the proposal
+     */
+    function createProposal(string calldata key, bytes32 value, bytes calldata metadataHash) external returns(uint256) {
+        require(metadataHash.length > 0, "metadataHash cannot be empty");
+
+        Gatekeeper gatekeeper = _gatekeeper();
+        return _createProposal(gatekeeper, key, value, metadataHash);
+    }
+
+    /**
      @dev Create multiple proposals to set values.
      @param keys The keys to set
      @param values The values to set for the keys
      @param metadataHashes Metadata hashes describing the proposals
     */
     function createManyProposals(
-        string[] memory keys,
-        bytes32[] memory values,
-        bytes[] memory metadataHashes
-    ) public {
-        require(keys.length == values.length, "All inputs must have the same length");
-        require(values.length == metadataHashes.length, "All inputs must have the same length");
+        string[] calldata keys,
+        bytes32[] calldata values,
+        bytes[] calldata metadataHashes
+    ) external {
+        require(
+            keys.length == values.length && values.length == metadataHashes.length,
+            "All inputs must have the same length"
+        );
 
+        Gatekeeper gatekeeper = _gatekeeper();
         for (uint i = 0; i < keys.length; i++) {
             string memory key = keys[i];
             bytes32 value = values[i];
             bytes memory metadataHash = metadataHashes[i];
-            createProposal(key, value, metadataHash);
+            _createProposal(gatekeeper, key, value, metadataHash);
         }
     }
 

--- a/governance-contracts/contracts/ParameterStore.sol
+++ b/governance-contracts/contracts/ParameterStore.sol
@@ -48,7 +48,7 @@ contract ParameterStore {
     */
     constructor(string[] memory _names, bytes32[] memory _values) public {
         owner = msg.sender;
-        // NOTE: _keys and _values must have the same length
+        require(_names.length == _values.length, "All inputs must have the same length");
 
         for (uint i = 0; i < _names.length; i++) {
             string memory name = _names[i];

--- a/governance-contracts/contracts/TokenCapacitor.sol
+++ b/governance-contracts/contracts/TokenCapacitor.sol
@@ -268,6 +268,8 @@ contract TokenCapacitor {
      @param time The time to update until. Must be less than 4096 days from the lastLockedTime.
      */
     function updateBalancesUntil(uint256 time) public {
+        require(time <= now, "No future updates");
+
         uint256 totalBalance = token.balanceOf(address(this));
 
         // Sweep the released tokens from locked into unlocked

--- a/governance-contracts/contracts/TokenCapacitor.sol
+++ b/governance-contracts/contracts/TokenCapacitor.sol
@@ -48,8 +48,7 @@ contract TokenCapacitor {
     Proposal[] public proposals;
 
     // Token decay table
-    uint256 constant PRECISION = 12;
-    uint256 public scale;
+    uint256 public constant SCALE = 10 ** 12;
     uint256[12] decayMultipliers;
 
     // Balances
@@ -88,8 +87,6 @@ contract TokenCapacitor {
         decayMultipliers[9] = 783688183013;
         decayMultipliers[10] = 614167168195;
         decayMultipliers[11] = 377201310488;
-
-        scale = 10 ** PRECISION;
 
         unlockedBalance = initialUnlockedBalance;
         lastLockedTime = now;
@@ -227,7 +224,7 @@ contract TokenCapacitor {
         // Based on the elapsed time (in days), calculate the decay factor
         uint256 decayFactor = calculateDecay(elapsedTime.div(86400));
 
-        return lastLockedBalance.mul(decayFactor).div(scale);
+        return lastLockedBalance.mul(decayFactor).div(SCALE);
     }
 
     /**
@@ -236,7 +233,7 @@ contract TokenCapacitor {
     function calculateDecay(uint256 _days) public view returns(uint256) {
         require(_days <= (2 ** decayMultipliers.length) - 1, "Time interval too large");
 
-        uint256 decay = scale;
+        uint256 decay = SCALE;
         uint256 d = _days;
 
         for (uint256 i = 0; i < decayMultipliers.length; i++) {
@@ -245,7 +242,7 @@ contract TokenCapacitor {
 
            if (remainder == 1) {
                 uint256 multiplier = decayMultipliers[i];
-                decay = decay.mul(multiplier).div(scale);
+                decay = decay.mul(multiplier).div(SCALE);
            } else if (quotient == 0) {
                // Exit early if both quotient and remainder are zero
                break;

--- a/governance-contracts/contracts/TokenCapacitor.sol
+++ b/governance-contracts/contracts/TokenCapacitor.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.10;
 pragma experimental ABIEncoderV2;
 
 import "./Gatekeeper.sol";

--- a/governance-contracts/contracts/TokenCapacitor.sol
+++ b/governance-contracts/contracts/TokenCapacitor.sol
@@ -44,11 +44,8 @@ contract TokenCapacitor {
         bool withdrawn;
     }
 
-    // The proposals created for the TokenCapacitor. Maps requestIDs to proposals.
-    mapping(uint => Proposal) public proposals;
-
-    // The total number of proposals
-    uint public proposalCount;
+    // The proposals created for the TokenCapacitor.
+    Proposal[] public proposals;
 
     // Token decay table
     uint256 constant PRECISION = 12;
@@ -126,9 +123,8 @@ contract TokenCapacitor {
         // proposalID.
         uint requestID = gatekeeper.requestPermission(metadataHash);
         p.requestID = requestID;
-        uint proposalID = proposalCount;
-        proposals[proposalID] = p;
-        proposalCount = proposalCount.add(1);
+        uint proposalID = proposalCount();
+        proposals.push(p);
 
         emit ProposalCreated(proposalID, msg.sender, requestID, to, tokens, metadataHash);
         return proposalID;
@@ -162,7 +158,7 @@ contract TokenCapacitor {
     @param proposalID The proposal
     */
     function withdrawTokens(uint proposalID) public returns(bool) {
-        require(proposalID < proposalCount, "Invalid proposalID");
+        require(proposalID < proposalCount(), "Invalid proposalID");
 
         Proposal memory p = proposals[proposalID];
         Gatekeeper gatekeeper = Gatekeeper(p.gatekeeper);
@@ -292,5 +288,9 @@ contract TokenCapacitor {
      */
     function updateBalances() public {
         updateBalancesUntil(now);
+    }
+
+    function proposalCount() public view returns(uint256) {
+        return proposals.length;
     }
 }

--- a/governance-contracts/contracts/dev/UpgradedGatekeeper.sol
+++ b/governance-contracts/contracts/dev/UpgradedGatekeeper.sol
@@ -68,8 +68,8 @@ contract UpgradedGatekeeper is Gatekeeper {
         // Note that some of the slates and requests will be uninitialized
         // If you were to use this pattern, then you would need to make sure to get the slates from
         // the appropriate gatekeepers
-        slateCount = previousGatekeeper.slateCount();
-        requestCount = previousGatekeeper.requestCount();
+        slates.length = previousGatekeeper.slateCount();
+        requests.length = previousGatekeeper.requestCount();
 
         // Handle contests we care about
         address capacitor = parameters.getAsAddress("tokenCapacitorAddress");

--- a/governance-contracts/test/gatekeeper.js
+++ b/governance-contracts/test/gatekeeper.js
@@ -2042,6 +2042,83 @@ contract('Gatekeeper', (accounts) => {
       didReveal.forEach(revealed => assert.strictEqual(revealed, true, 'Voter should have revealed'));
     });
 
+    describe('input lengths', () => {
+      let voters;
+      let ballots;
+      let salts;
+
+      beforeEach(async () => {
+        // Advance to commit period
+        await increaseTime(timing.VOTING_PERIOD_START);
+
+        const [aliceSalt, bobSalt, carolSalt] = ['1234', '5678', '9012'];
+
+        const aliceReveal = await commitBallot(gatekeeper, alice, [[GRANT, 0, 1], [GOVERNANCE, 2, 3]], '1000', aliceSalt);
+        const bobReveal = await commitBallot(gatekeeper, bob, [[GRANT, 0, 1], [GOVERNANCE, 2, 3]], '1000', bobSalt);
+        const carolReveal = await commitBallot(gatekeeper, carol, [[GRANT, 1, 0], [GOVERNANCE, 2, 3]], '1000', carolSalt);
+
+        // Prepare data
+        voters = [alice, bob, carol];
+        ballots = [aliceReveal, bobReveal, carolReveal].map(_reveal => utils.encodeBallot(
+          _reveal.resources,
+          _reveal.firstChoices,
+          _reveal.secondChoices,
+        ));
+        salts = [aliceSalt, bobSalt, carolSalt];
+
+        // Advance to reveal period
+        await increaseTime(timing.COMMIT_PERIOD_LENGTH);
+      });
+
+      it('should revert if the length of salts is short', async () => {
+        try {
+          await gatekeeper.revealManyBallots(
+            epochNumber,
+            voters,
+            ballots,
+            salts.slice(0, 1),
+          );
+        } catch (error) {
+          expectRevert(error);
+          expectErrorLike(error, 'same length');
+          return;
+        }
+        assert.fail('Allowed revealManyBallots with short salts');
+      });
+
+      it('should revert if the length of voters is short', async () => {
+        try {
+          await gatekeeper.revealManyBallots(
+            epochNumber,
+            voters.slice(0, 1),
+            ballots,
+            salts,
+          );
+        } catch (error) {
+          expectRevert(error);
+          expectErrorLike(error, 'same length');
+          return;
+        }
+        assert.fail('Allowed revealManyBallots with short voters');
+      });
+
+      it('should revert if the length of ballots is short', async () => {
+        try {
+          await gatekeeper.revealManyBallots(
+            epochNumber,
+            voters,
+            ballots.slice(0, 1),
+            salts,
+          );
+        } catch (error) {
+          expectRevert(error);
+          expectErrorLike(error, 'same length');
+          return;
+        }
+        assert.fail('Allowed revealManyBallots with short ballots');
+      });
+    });
+
     afterEach(async () => utils.evm.revert(snapshotID));
   });
 

--- a/governance-contracts/test/integration.js
+++ b/governance-contracts/test/integration.js
@@ -59,7 +59,7 @@ contract('integration', (accounts) => {
       await utils.chargeCapacitor(capacitor, 50e6, token, { from: creator });
 
       GRANT = await getResource(gatekeeper, 'GRANT');
-      scale = await capacitor.scale();
+      scale = await capacitor.SCALE();
 
       // Make sure the recommender has tokens
       const recommenderTokens = toPanBase('50000000');

--- a/governance-contracts/test/parameterStore.js
+++ b/governance-contracts/test/parameterStore.js
@@ -44,6 +44,21 @@ contract('ParameterStore', (accounts) => {
     it('should be okay with no initial values', async () => {
       await ParameterStore.new([], []);
     });
+
+    it('should revert if the length of keys and values is not equal', async () => {
+      try {
+        await ParameterStore.new(
+          names.slice(0, 1),
+          values,
+          { from: creator },
+        );
+      } catch (error) {
+        expectRevert(error);
+        expectErrorLike(error, 'same length');
+        return;
+      }
+      assert.fail('Allowed construction with uneven key/value lengths');
+    });
   });
 
   describe('init', () => {

--- a/governance-contracts/test/tokenCapacitor.js
+++ b/governance-contracts/test/tokenCapacitor.js
@@ -775,7 +775,7 @@ contract('TokenCapacitor', (accounts) => {
       before(async () => {
         ({ token, capacitor } = await utils.newPanvala({ from: creator }));
         await utils.chargeCapacitor(capacitor, supply, token, { from: creator });
-        scale = await capacitor.scale();
+        scale = await capacitor.SCALE();
       });
 
       beforeEach(async () => {
@@ -926,7 +926,7 @@ contract('TokenCapacitor', (accounts) => {
         ({ token, capacitor } = await utils.newPanvala({ from: creator }));
         await token.transfer(capacitor.address, supply, { from: creator });
         await capacitor.updateBalances({ from: creator });
-        scale = await capacitor.scale();
+        scale = await capacitor.SCALE();
       });
 
       const tests = [
@@ -1006,7 +1006,7 @@ contract('TokenCapacitor', (accounts) => {
         await token.transfer(capacitor.address, supply, { from: creator });
         await capacitor.updateBalances();
 
-        scale = await capacitor.scale();
+        scale = await capacitor.SCALE();
       });
 
       const tests = [

--- a/governance-contracts/test/tokenCapacitor.js
+++ b/governance-contracts/test/tokenCapacitor.js
@@ -774,8 +774,7 @@ contract('TokenCapacitor', (accounts) => {
 
       before(async () => {
         ({ token, capacitor } = await utils.newPanvala({ from: creator }));
-        await token.transfer(capacitor.address, supply, { from: creator });
-        await capacitor.updateBalances({ from: creator });
+        await utils.chargeCapacitor(capacitor, supply, token, { from: creator });
         scale = await capacitor.scale();
       });
 
@@ -794,7 +793,7 @@ contract('TokenCapacitor', (accounts) => {
         it(`should decrease the locked balance and increase the unlocked balance properly for ${
           test.label
         }`, async () => {
-          const initial = new BN(supply);
+          const initial = new BN(toPanBase(supply));
           assert.strictEqual(
             (await capacitor.lastLockedBalance()).toString(),
             initial.toString(),
@@ -848,7 +847,7 @@ contract('TokenCapacitor', (accounts) => {
       });
 
       it('should increase the locked balance if the balance increases outside `donate()`', async () => {
-        const increase = new BN(10000);
+        const increase = new BN(toPanBase(10000));
         await token.transfer(capacitor.address, increase, { from: creator });
 
         const {

--- a/governance-contracts/test/tokenCapacitor.js
+++ b/governance-contracts/test/tokenCapacitor.js
@@ -898,6 +898,21 @@ contract('TokenCapacitor', (accounts) => {
         await capacitor.updateBalances({ from: creator });
       });
 
+      it('should revert if updateBalancesUntil() is called with a time in the future', async () => {
+        const start = await utils.evm.timestamp();
+        const time = (new BN(start)).add(timing.ONE_DAY.muln(4000));
+
+        // Unlock those tokens, yeah!
+        try {
+          await capacitor.updateBalancesUntil(time, { from: creator });
+        } catch (error) {
+          expectRevert(error);
+          expectErrorLike(error, 'No future');
+          return;
+        }
+        assert.fail('Called updateBalancesUntil() with a time in the future');
+      });
+
       afterEach(async () => utils.evm.revert(snapshotID));
     });
 

--- a/governance-contracts/truffle-config.js
+++ b/governance-contracts/truffle-config.js
@@ -134,7 +134,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: '0.5.1',    // Fetch exact version from solc-bin (default: truffle's version)
+      version: '0.5.10',    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       settings: {          // See the solidity docs for advice about optimization and evmVersion
         optimizer: {


### PR DESCRIPTION
Address audit issue 7.24. Replace `slates` and `requests` mappings in the `Gatekeeper` with arrays and include getters.