### PR TITLE
Make balance unlocking more robust

### DIFF
--- a/governance-contracts/contracts/TokenCapacitor.sol
+++ b/governance-contracts/contracts/TokenCapacitor.sol
@@ -91,7 +91,10 @@ contract TokenCapacitor {
         decayMultipliers[11] = 377201310488;
 
         unlockedBalance = initialUnlockedBalance;
-        lastLockedTime = now;
+
+        // initialize update time at an even number of days relative to gatekeeper start
+        lastLockedTime = _gatekeeper().startTime();
+        lastLockedTime = lastLockedTime.add(_adjustedElapsedTime(now));
     }
 
     function _gatekeeper() private view returns(Gatekeeper) {

--- a/governance-contracts/test/integration.js
+++ b/governance-contracts/test/integration.js
@@ -970,9 +970,9 @@ contract('integration', (accounts) => {
 
       // expected values
       const initialUnlockedBalance = new BN('496443351836365210000000');
-      const projectedUnlocked = new BN('2093106861568889766839236');
+      const expectedProjectedUnlocked = new BN('2115863519962730001675795');
       const lockedAtLaunch = new BN('49409859648163634790000000');
-      const releasedAfterLaunch = projectedUnlocked.sub(initialUnlockedBalance);
+      const releasedAfterLaunch = expectedProjectedUnlocked.sub(initialUnlockedBalance);
 
       // const daysElapsed = daysBetween(systemStart, launchDay);
       // const lockedAtLaunch = decay(initialBalance, daysElapsed);
@@ -1009,7 +1009,7 @@ contract('integration', (accounts) => {
       // withdraw the right amount after epoch end
       // initial unlocked + decay from lockedAtLaunch
       const nextEpochStart = await gatekeeper.epochStart(epochNumber.addn(1));
-      const expectedProjectedUnlocked = await capacitor.projectedUnlockedBalance(nextEpochStart);
+      const projectedUnlocked = await capacitor.projectedUnlockedBalance(nextEpochStart);
       // printTokens(projectedUnlocked, 'projected unlocked');
 
       // // check that our calculation matches the projection

--- a/governance-contracts/test/tokenCapacitor.js
+++ b/governance-contracts/test/tokenCapacitor.js
@@ -995,8 +995,8 @@ contract('TokenCapacitor', (accounts) => {
       });
 
       it('should revert if time is before lastLockedTime', async () => {
-        const now = await utils.evm.timestamp();
-        const time = (new BN(now)).sub(timing.ONE_SECOND);
+        const lastLockedTime = await capacitor.lastLockedTime();
+        const time = lastLockedTime.sub(timing.ONE_SECOND);
 
         try {
           await capacitor.projectedLockedBalance(time);
@@ -1076,8 +1076,8 @@ contract('TokenCapacitor', (accounts) => {
       });
 
       it('should revert if time is before lastLockedTime', async () => {
-        const now = await utils.evm.timestamp();
-        const time = (new BN(now)).sub(timing.ONE_SECOND);
+        const lastLockedTime = await capacitor.lastLockedTime();
+        const time = lastLockedTime.sub(timing.ONE_SECOND);
 
         try {
           await capacitor.projectedUnlockedBalance(time);

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -30,6 +30,7 @@ const testProvider = new ethers.providers.JsonRpcProvider('http://localhost:8545
 const ONE_WEEK = new BN('604800');
 const timing = {
   ONE_SECOND: new BN(1),
+  ONE_HOUR: new BN(3600),
   ONE_DAY: new BN(3600 * 24),
   ONE_WEEK,
   EPOCH_LENGTH: ONE_WEEK.mul(new BN(13)),

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -635,6 +635,17 @@ async function capacitorBalances(capacitor) {
   return { unlocked, locked };
 }
 
+/**
+ * Get capacitor lock time adjusted to the initial lock time
+ * @param {BN} initialLockedTime
+ * @param {number) time
+ */
+function adjustedLockTime(initialLockedTime, time) {
+  const elapsedTime = (new BN(time)).sub(initialLockedTime);
+  const adjusted = elapsedTime.sub(elapsedTime.mod(timing.ONE_DAY));
+  return initialLockedTime.add(adjusted);
+}
+
 const utils = {
   expectRevert,
   expectEvents,
@@ -686,6 +697,7 @@ const utils = {
   loadTokenReleases,
   capacitorBalances,
   chargeCapacitor,
+  adjustedLockTime,
 };
 
 module.exports = utils;


### PR DESCRIPTION
Address audit issues 7.2 and 7.3.

Change public `updateBalancesUntil()` to internal `_updateBalanceUntil()` and instead let `updateBalances()` automatically catch up if necessary. In addition, add a test that we can call `updateBalances()` even if many lifetimes have passed since the last one.

Before, calls to `updateBalances()` within a day (24 hours) of the last update would not change the balances, but would update `lastLockedTime`, causing tokens to never get unlocked if this happened repeatedly. This modifies the update logic to only unlock tokens after full days so that the `lastLockedTime` only updates when tokens are actually unlocked.