### PR TITLE
Prevent uninitialized paramstore

### DIFF
--- a/governance-contracts/contracts/ParameterStore.sol
+++ b/governance-contracts/contracts/ParameterStore.sol
@@ -24,7 +24,7 @@ contract ParameterStore {
     using SafeMath for uint256;
 
     address owner;
-    bool initialized;
+    bool public initialized;
     mapping(bytes32 => bytes32) public params;
 
     // A proposal to change a value

--- a/governance-contracts/contracts/ParameterStore.sol
+++ b/governance-contracts/contracts/ParameterStore.sol
@@ -150,6 +150,7 @@ contract ParameterStore {
      */
     function createProposal(string calldata key, bytes32 value, bytes calldata metadataHash) external returns(uint256) {
         require(metadataHash.length > 0, "metadataHash cannot be empty");
+        require(initialized, "Contract has not yet been initialized");
 
         Gatekeeper gatekeeper = _gatekeeper();
         return _createProposal(gatekeeper, key, value, metadataHash);
@@ -187,6 +188,7 @@ contract ParameterStore {
      */
     function setValue(uint256 proposalID) public returns(bool) {
         require(proposalID < proposalCount(), "Invalid proposalID");
+        require(initialized, "Contract has not yet been initialized");
 
         Proposal memory p = proposals[proposalID];
         Gatekeeper gatekeeper = Gatekeeper(p.gatekeeper);

--- a/governance-contracts/test/gatekeeper.js
+++ b/governance-contracts/test/gatekeeper.js
@@ -240,7 +240,7 @@ contract('Gatekeeper', (accounts) => {
     const halfVotingPeriod = votingPeriodLength.div(new BN(2));
 
     beforeEach(async () => {
-      gatekeeper = await utils.newGatekeeper({ startTime, from: creator, init: true });
+      gatekeeper = await utils.newGatekeeper({ startTime, from: creator });
 
       GRANT = await getResource(gatekeeper, 'GRANT');
     });
@@ -1108,10 +1108,6 @@ contract('Gatekeeper', (accounts) => {
       }
       assert.fail('allowed creation of a request after the deadline passed (reveal vote stage)');
     });
-
-    afterEach(async () => {
-      await utils.evm.revert(snapshotID);
-    });
   });
 
   describe('depositVoteTokens', () => {
@@ -1695,7 +1691,7 @@ contract('Gatekeeper', (accounts) => {
       } = await utils.newPanvala({
         from: creator,
       }));
-      await parameters.init();
+
       epochNumber = await gatekeeper.currentEpochNumber();
       GRANT = await getResource(gatekeeper, 'GRANT');
       GOVERNANCE = await getResource(gatekeeper, 'GOVERNANCE');
@@ -2127,7 +2123,7 @@ contract('Gatekeeper', (accounts) => {
       ({
         gatekeeper, capacitor, token, parameters,
       } = await utils.newPanvala({ from: creator }));
-      await parameters.init();
+
       epochNumber = await gatekeeper.currentEpochNumber();
       GRANT = await getResource(gatekeeper, 'GRANT');
       GOVERNANCE = await getResource(gatekeeper, 'GOVERNANCE');
@@ -2348,7 +2344,7 @@ contract('Gatekeeper', (accounts) => {
       } = await utils.newPanvala({
         from: creator,
       }));
-      await parameterStore.init();
+
       epochNumber = await gatekeeper.currentEpochNumber();
 
       GRANT = await getResource(gatekeeper, 'GRANT');
@@ -2502,7 +2498,7 @@ contract('Gatekeeper', (accounts) => {
       ({
         gatekeeper, token, capacitor, parameters: parameterStore,
       } = await utils.newPanvala({ from: creator }));
-      await parameterStore.init();
+
       epochNumber = await gatekeeper.currentEpochNumber();
 
       GRANT = await getResource(gatekeeper, 'GRANT');

--- a/governance-contracts/test/gatekeeper.js
+++ b/governance-contracts/test/gatekeeper.js
@@ -240,7 +240,7 @@ contract('Gatekeeper', (accounts) => {
     const halfVotingPeriod = votingPeriodLength.div(new BN(2));
 
     beforeEach(async () => {
-      gatekeeper = await utils.newGatekeeper({ startTime, from: creator });
+      gatekeeper = await utils.newGatekeeper({ startTime, from: creator, init: true });
 
       GRANT = await getResource(gatekeeper, 'GRANT');
     });
@@ -1695,6 +1695,7 @@ contract('Gatekeeper', (accounts) => {
       } = await utils.newPanvala({
         from: creator,
       }));
+      await parameters.init();
       epochNumber = await gatekeeper.currentEpochNumber();
       GRANT = await getResource(gatekeeper, 'GRANT');
       GOVERNANCE = await getResource(gatekeeper, 'GOVERNANCE');
@@ -2126,6 +2127,7 @@ contract('Gatekeeper', (accounts) => {
       ({
         gatekeeper, capacitor, token, parameters,
       } = await utils.newPanvala({ from: creator }));
+      await parameters.init();
       epochNumber = await gatekeeper.currentEpochNumber();
       GRANT = await getResource(gatekeeper, 'GRANT');
       GOVERNANCE = await getResource(gatekeeper, 'GOVERNANCE');
@@ -2346,6 +2348,7 @@ contract('Gatekeeper', (accounts) => {
       } = await utils.newPanvala({
         from: creator,
       }));
+      await parameterStore.init();
       epochNumber = await gatekeeper.currentEpochNumber();
 
       GRANT = await getResource(gatekeeper, 'GRANT');
@@ -2499,6 +2502,7 @@ contract('Gatekeeper', (accounts) => {
       ({
         gatekeeper, token, capacitor, parameters: parameterStore,
       } = await utils.newPanvala({ from: creator }));
+      await parameterStore.init();
       epochNumber = await gatekeeper.currentEpochNumber();
 
       GRANT = await getResource(gatekeeper, 'GRANT');

--- a/governance-contracts/test/integration.js
+++ b/governance-contracts/test/integration.js
@@ -37,7 +37,7 @@ function lockedTokens(multipliers, scale, startingBalance, days) {
   return locked;
 }
 
-contract('integration', (accounts) => {
+contract.skip('integration', (accounts) => {
   const multipliers = loadDecayMultipliers();
   let snapshotID;
 

--- a/governance-contracts/test/integration.js
+++ b/governance-contracts/test/integration.js
@@ -37,7 +37,7 @@ function lockedTokens(multipliers, scale, startingBalance, days) {
   return locked;
 }
 
-contract.skip('integration', (accounts) => {
+contract('integration', (accounts) => {
   const multipliers = loadDecayMultipliers();
   let snapshotID;
 

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -345,7 +345,12 @@ async function newGatekeeper(options) {
  * @param {*} options from, startTime, parameterStoreAddress, tokenAddress, initialUnlockedBalance
  */
 async function newPanvala(options) {
-  const { from: creator, initialTokens, initialUnlockedBalance = toPanBase('0') } = options;
+  const {
+    from: creator,
+    initialTokens,
+    initialUnlockedBalance = toPanBase('0'),
+    init = true,
+  } = options;
   assert(typeof initialTokens === 'undefined', 'should not have key initialTokens');
 
   const gatekeeper = await newGatekeeper({ ...options, init: false });
@@ -369,6 +374,10 @@ async function newPanvala(options) {
   // console.log(`Gatekeeper: ${gatekeeper.address}`);
   // console.log(`TokenCapacitor: ${capacitor.address}`);
   // console.log(`Token: ${token.address}`);
+
+  if (init) {
+    await parameters.init({ from: creator });
+  }
 
   return {
     gatekeeper, parameters, capacitor, token,


### PR DESCRIPTION
Address audit issue 7.9.

the owner of `ParameterStore` may choose to never call `init()` and remain in control of the `ParameterStore` being able to arbitrarily change values without requiring a proposal to perform it (via `setInitialValue()`). this pr prevents calls to `createProposal` and `setValue` if the value of `initialized` is false. this pr also adds a `public` visibility modifier to the `initialized` value so as to be transparent about the state of the contract