### PR TITLE
check for allowance prior to staking on a slate

### DIFF
--- a/client/pages/slates/create/grant.tsx
+++ b/client/pages/slates/create/grant.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Formik, Form, FormikContext } from 'formik';
 import { TransactionResponse, TransactionReceipt } from 'ethers/providers';
 import { utils } from 'ethers';
+import { MaxUint256 } from 'ethers/constants';
 import { ContractReceipt } from 'ethers/contract';
 import { toast } from 'react-toastify';
 import * as yup from 'yup';
@@ -111,6 +112,7 @@ const CreateGrantSlate: StatelessPage<IProps> = ({ query, router }) => {
     contracts,
     onRefreshBalances,
     slateStakeAmount,
+    gkAllowance,
   }: IEthereumContext = React.useContext(EthereumContext);
 
   React.useEffect(() => {
@@ -337,6 +339,9 @@ const CreateGrantSlate: StatelessPage<IProps> = ({ query, router }) => {
             // stake immediately after creating slate
             if (values.stake === 'yes') {
               setTxPending(true);
+              if (gkAllowance.lt(slateStakeAmount)) {
+                await contracts.token.approve(contracts.gatekeeper.address, MaxUint256);
+              }
               const res = await sendStakeTokensTransaction(contracts.gatekeeper, slate.slateID);
 
               await res.wait();


### PR DESCRIPTION
resolves #133 

previously, during slate creation, the option to immediately stake on a slate did not first check to see that a user has enough allowance to stake. this pr adds a check for allowance & sends the approve tx if the user has not allowed the gatekeeper enough tokens to stake on a slate.