### PR TITLE
Enforce that requests in slates are current

### DIFF
--- a/governance-contracts/contracts/dev/UpgradedGatekeeper.sol
+++ b/governance-contracts/contracts/dev/UpgradedGatekeeper.sol
@@ -98,14 +98,16 @@ contract UpgradedGatekeeper is Gatekeeper {
                bytes memory metadataHash,
                address _resource,
                bool approved,
-               uint256 expirationTime
+               uint256 expirationTime,
+               // skip: epochNumber
            ) = previousGatekeeper.requests(requestID);
 
            requests[requestID] = Request({
                metadataHash: metadataHash,
                resource: _resource,
                approved: approved,
-               expirationTime: expirationTime
+               expirationTime: expirationTime,
+               epochNumber: epochNumber
            });
         }
 


### PR DESCRIPTION
Address audit issue 7.4.

Before, it was possible to include requests from previous epochs in a slate. These requests might already be approved or expired, and therefore not able to be executed. To avoid this, store the epoch number associated with a request, and validate that it was created in the current epoch when creating a slate.