### PR TITLE
Add donation receiver interface

### DIFF
--- a/governance-contracts/contracts/Gatekeeper.sol
+++ b/governance-contracts/contracts/Gatekeeper.sol
@@ -2,7 +2,7 @@ pragma solidity 0.5.10;
 pragma experimental ABIEncoderV2;
 
 import "./ParameterStore.sol";
-import "./TokenCapacitor.sol";
+import "./IDonationReceiver.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 
@@ -835,8 +835,8 @@ contract Gatekeeper {
         uint256 endIndex = startIndex.add(count);
         require(endIndex <= numSlates, "Invalid end index");
 
-        address tokenCapacitorAddress = parameters.getAsAddress("tokenCapacitorAddress");
-        TokenCapacitor capacitor = TokenCapacitor(tokenCapacitorAddress);
+        address stakeDonationAddress = parameters.getAsAddress("stakeDonationAddress");
+        IDonationReceiver donationReceiver = IDonationReceiver(stakeDonationAddress);
         bytes memory stakeDonationHash = "Qmepxeh4KVkyHYgt3vTjmodB5RKZgUEmdohBZ37oKXCUCm";
 
         for (uint256 i = startIndex; i < endIndex; i++) {
@@ -849,10 +849,10 @@ contract Gatekeeper {
                 // Only donate for non-zero amounts
                 if (donationAmount > 0) {
                     require(
-                        token.approve(address(capacitor), donationAmount),
+                        token.approve(address(donationReceiver), donationAmount),
                         "Failed to approve Gatekeeper to spend tokens"
                     );
-                    capacitor.donate(address(this), donationAmount, stakeDonationHash);
+                    donationReceiver.donate(address(this), donationAmount, stakeDonationHash);
                 }
             }
         }

--- a/governance-contracts/contracts/IDonationReceiver.sol
+++ b/governance-contracts/contracts/IDonationReceiver.sol
@@ -1,0 +1,11 @@
+pragma solidity 0.5.10;
+
+/**
+ * @title Donation receiver interface
+ * @dev Contracts (like the TokenCapacitor) that can receive donations
+ */
+interface IDonationReceiver {
+    event Donation(address indexed payer, address indexed donor, uint numTokens, bytes metadataHash);
+
+    function donate(address donor, uint tokens, bytes calldata metadataHash) external returns(bool);
+}

--- a/governance-contracts/contracts/TokenCapacitor.sol
+++ b/governance-contracts/contracts/TokenCapacitor.sol
@@ -3,11 +3,12 @@ pragma experimental ABIEncoderV2;
 
 import "./Gatekeeper.sol";
 import "./ParameterStore.sol";
+import "./IDonationReceiver.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 
 
-contract TokenCapacitor {
+contract TokenCapacitor is IDonationReceiver {
     // EVENTS
     event ProposalCreated(
         uint256 proposalID,
@@ -18,7 +19,6 @@ contract TokenCapacitor {
         bytes metadataHash
     );
     event TokensWithdrawn(uint proposalID, address indexed to, uint numTokens);
-    event Donation(address indexed payer, address indexed donor, uint numTokens, bytes metadataHash);
     event BalancesUpdated(
         uint unlockedBalance,
         uint lastLockedBalance,

--- a/governance-contracts/contracts/dev/UpgradedGatekeeper.sol
+++ b/governance-contracts/contracts/dev/UpgradedGatekeeper.sol
@@ -37,14 +37,14 @@ contract UpgradedGatekeeper is Gatekeeper {
         startTime = previousGatekeeper.startTime();
     }
 
-    function init() public {
+    function init(address[] memory resources) public {
         require(initialized == false, "Already initialized");
 
         // Do not allow initialization until this gatekeeper has been accepted
         address gatekeeperAddress = parameters.getAsAddress("gatekeeperAddress");
         require(gatekeeperAddress == address(this), "Not ready");
 
-        migrateState();
+        migrateState(resources);
 
         initialized = true;
     }
@@ -63,7 +63,7 @@ contract UpgradedGatekeeper is Gatekeeper {
     /**
      @dev Migrate state from the previous gatekeeper
      */
-    function migrateState() private {
+    function migrateState(address[] memory resources) private {
         // Continue from where the previous one left off
         // Note that some of the slates and requests will be uninitialized
         // If you were to use this pattern, then you would need to make sure to get the slates from
@@ -72,9 +72,9 @@ contract UpgradedGatekeeper is Gatekeeper {
         requests.length = previousGatekeeper.requestCount();
 
         // Handle contests we care about
-        address capacitor = parameters.getAsAddress("tokenCapacitorAddress");
-        migrateContest(epochToTransfer, capacitor);
-        migrateContest(epochToTransfer, address(parameters));
+        for (uint i = 0; i < resources.length; i++) {
+            migrateContest(epochToTransfer, resources[i]);
+        }
     }
 
     /**

--- a/governance-contracts/migrations/5_token_capacitor.js
+++ b/governance-contracts/migrations/5_token_capacitor.js
@@ -26,7 +26,7 @@ module.exports = async function(deployer, _, accounts) {
   );
 
   await parameters.setInitialValue(
-    'tokenCapacitorAddress',
+    'stakeDonationAddress',
     abiEncode('address', capacitor.address) // eslint-disable-line comma-dangle
   );
 

--- a/governance-contracts/test/integration.js
+++ b/governance-contracts/test/integration.js
@@ -507,11 +507,13 @@ contract('integration', (accounts) => {
       const gatekeeperKey = 'gatekeeperAddress';
       const transferResources = [];
 
-      // go through upgrade up until point before governance proposal execution
-      beforeEach(async () => {
+      before(() => {
         transferResources.push(capacitor.address);
         transferResources.push(parameters.address);
+      });
 
+      // go through upgrade up until point before governance proposal execution
+      beforeEach(async () => {
         // ===== EPOCH 0
         const startingEpoch = await gatekeeper.currentEpochNumber();
         await token.approve(gatekeeper.address, toPanBase('100000'), { from: creator });

--- a/governance-contracts/test/integration.js
+++ b/governance-contracts/test/integration.js
@@ -505,9 +505,13 @@ contract('integration', (accounts) => {
       let grantWinner;
       let oldGovernancePermissions;
       const gatekeeperKey = 'gatekeeperAddress';
+      const transferResources = [];
 
       // go through upgrade up until point before governance proposal execution
       beforeEach(async () => {
+        transferResources.push(capacitor.address);
+        transferResources.push(parameters.address);
+
         // ===== EPOCH 0
         const startingEpoch = await gatekeeper.currentEpochNumber();
         await token.approve(gatekeeper.address, toPanBase('100000'), { from: creator });
@@ -613,7 +617,7 @@ contract('integration', (accounts) => {
         assert(storedGatekeeper !== newGatekeeper.address, 'Wrong gatekeeper address');
 
         try {
-          await newGatekeeper.init({ from: creator });
+          await newGatekeeper.init(transferResources, { from: creator });
         } catch (error) {
           expectRevert(error);
           expectErrorLike(error, 'Not ready');
@@ -639,7 +643,7 @@ contract('integration', (accounts) => {
 
         // activate new gatekeeper
         utils.pMap(p => parameters.setValue(p), oldGovernancePermissions);
-        await newGatekeeper.init({ from: creator });
+        await newGatekeeper.init(transferResources, { from: creator });
 
         // stake
         try {
@@ -672,7 +676,7 @@ contract('integration', (accounts) => {
 
         // activate new gatekeeper
         utils.pMap(p => parameters.setValue(p), oldGovernancePermissions);
-        await newGatekeeper.init({ from: creator });
+        await newGatekeeper.init(transferResources, { from: creator });
 
         // try to finalize
         await goToPeriod(gatekeeper, epochPeriods.END);
@@ -697,7 +701,7 @@ contract('integration', (accounts) => {
 
         it('should do an upgrade of the gatekeeper while migrating existing state', async () => {
           // migrate state
-          await newGatekeeper.init({ from: creator });
+          await newGatekeeper.init(transferResources, { from: creator });
 
           // check state
           const epochNumber = await newGatekeeper.currentEpochNumber();

--- a/governance-contracts/test/utils.js
+++ b/governance-contracts/test/utils.js
@@ -366,7 +366,7 @@ async function newPanvala(options) {
   );
 
   await parameters.setInitialValue(
-    'tokenCapacitorAddress',
+    'stakeDonationAddress',
     abiCoder.encode(['address'], [capacitor.address]),
     { from: creator },
   );
@@ -518,7 +518,8 @@ async function getResource(gatekeeper, name) {
 
   if (name === 'GRANT') {
     const parameterStore = await ParameterStore.at(parametersAddress);
-    source = await parameterStore.getAsAddress('tokenCapacitorAddress');
+    // NOTE: this is a hack, since in the future, this isn't guaranteed to be the token capacitor
+    source = await parameterStore.getAsAddress('stakeDonationAddress');
   } else if (name === 'GOVERNANCE') {
     source = parametersAddress;
   } else {


### PR DESCRIPTION
Make the address where losing stakes are donated more generic by adding an interface `IDonationReceiver`. Change `tokenCapacitorAddress` parameter to `stakeDonationAddress`.