### PR TITLE
More clearly indicate connection to the wrong network

### DIFF
--- a/client/components/EthereumProvider.tsx
+++ b/client/components/EthereumProvider.tsx
@@ -134,7 +134,7 @@ const EthereumProvider: React.FC<any> = (props: any) => {
             });
 
             if (!isEmpty(ethProvider)) {
-              setupContracts(ethProvider);
+              await setupContracts(ethProvider);
             }
           } catch (error) {
             console.error(`ERROR failed to connect eth provider: ${error.message}`);
@@ -159,6 +159,8 @@ const EthereumProvider: React.FC<any> = (props: any) => {
               console.error(`ERROR failed to connect contracts: ${error.message}`);
               if (error.message.includes('contract not deployed')) {
                 toast.error(`Contracts not deployed on current network`);
+              } else if (error.message.includes('Wrong network')) {
+                toast.error(error.message);
               }
               throw error;
             }


### PR DESCRIPTION
Before, our method of checking whether the user is connected to the wrong network was broken. This fixes it by more explicitly checking the provider network against the expected network (based on `PANVALA_ENV`). It also shows a toast that tells the user the current and expected networks.