### PR TITLE
First pass at better frontend error-handling

### DIFF
--- a/client/pages/Wallet.tsx
+++ b/client/pages/Wallet.tsx
@@ -20,6 +20,7 @@ import { IEthereumContext, EthereumContext } from '../components/EthereumProvide
 import { saveState, loadState, LINKED_WALLETS } from '../utils/localStorage';
 import { splitAddressHumanReadable, isAddress } from '../utils/format';
 import { COLORS } from '../styles';
+import { handleGenericError } from '../utils/errors';
 
 const CancelButton = styled(Button)`
   color: ${COLORS.grey3};
@@ -150,11 +151,22 @@ const Wallet: React.SFC = () => {
 
         onRefreshBalances();
       } catch (error) {
-        if (!error.message.includes('User denied message signature.')) {
-          throw error;
-        }
+        handleLinkError(error);
       }
     }
+  }
+
+  function handleLinkError(error: Error) {
+    // Return the user to where they were
+    setTxPending(false);
+    setStep(0);
+
+    // Display message
+    const errorType = handleGenericError(error, toast);
+    if (errorType) {
+      toast.error(`Problem linking wallets: ${error.message}`);
+    }
+    console.error(error);
   }
 
   const steps = [

--- a/client/pages/Withdraw.tsx
+++ b/client/pages/Withdraw.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import isEmpty from 'lodash/isEmpty';
+import { toast } from 'react-toastify';
 
 import CenteredWrapper from '../components/CenteredWrapper';
 import CenteredTitle from '../components/CenteredTitle';
@@ -14,6 +15,7 @@ import { StatelessPage } from '../interfaces';
 import { sendAndWaitForTransaction } from '../utils/transaction';
 import { tsToDeadline } from '../utils/datetime';
 import PendingTransaction from '../components/PendingTransaction';
+import { handleGenericError } from '../utils/errors';
 
 const CenteredSection = styled.div`
   padding: 2rem;
@@ -49,10 +51,23 @@ const Withdraw: StatelessPage<IProps> = ({ query, asPath }) => {
     }
   }, [gatekeeper, query.id]);
 
+  function handleWithdrawError(error: Error) {
+    // Reset view
+    setTxPending(false);
+
+    // Show a message
+    const errorType = handleGenericError(error, toast);
+    if (errorType) {
+      toast.error(`Failed to withdraw tokens: ${error.message}`);
+    }
+
+    console.error(`Failed to withdraw tokens: ${error}`);
+  }
+
   async function handleWithdraw(method: string, args: string) {
     try {
       if (account && !isEmpty(gatekeeper)) {
-        const contract = method === 'withdrawTokens' ? tokenCapacitor : gatekeeper;
+        const contract = method === 'withdrawTkens' ? tokenCapacitor : gatekeeper;
         setTxPending(true);
         await sendAndWaitForTransaction(ethProvider, contract, method, [args]);
         setTxPending(false);
@@ -60,8 +75,7 @@ const Withdraw: StatelessPage<IProps> = ({ query, asPath }) => {
         onRefreshSlates();
       }
     } catch (error) {
-      console.error(`ERROR failed to withdraw tokens: ${error.message}`);
-      throw error;
+      handleWithdrawError(error);
     }
   }
 

--- a/client/pages/proposals/create.tsx
+++ b/client/pages/proposals/create.tsx
@@ -13,6 +13,7 @@ import { postProposal } from '../../utils/api';
 import { IProposal } from '../../interfaces';
 import RouterLink from '../../components/RouterLink';
 import Loader from '../../components/Loader';
+import { handleGenericError } from '../../utils/errors';
 
 const CreateProposal: React.FC = () => {
   const { onRefreshProposals }: IMainContext = React.useContext(MainContext);
@@ -30,10 +31,25 @@ const CreateProposal: React.FC = () => {
         setTxPending(false);
         setOpenModal(true);
         await onRefreshProposals();
+      } else {
+        handleSubmissionError(new Error(`Problem creating proposal: ${response.data}`));
       }
     } catch (error) {
-      toast.error(error.message);
+      handleSubmissionError(error);
     }
+  }
+
+  function handleSubmissionError(error: Error) {
+    // Reset view
+    setTxPending(false);
+    setOpenModal(false);
+
+    // Show message
+    const errorType = handleGenericError(error, toast);
+    if (errorType) {
+      toast.error(`Problem creating proposal: ${error.message}`);
+    }
+    console.error(error);
   }
 
   return (

--- a/client/pages/slates/create/governance.tsx
+++ b/client/pages/slates/create/governance.tsx
@@ -25,6 +25,7 @@ import SectionLabel from '../../../components/SectionLabel';
 import { convertedToBaseUnits, formatPanvalaUnits } from '../../../utils/format';
 import { ipfsAddObject } from '../../../utils/ipfs';
 import { postSlate } from '../../../utils/api';
+import { handleGenericError } from '../../../utils/errors';
 import {
   ISaveSlate,
   StatelessPage,
@@ -227,12 +228,24 @@ const CreateGovernanceSlate: StatelessPage<any> = ({ classes, router }) => {
       }
     } catch (error) {
       errorMessage = `ERROR: ${errorMessage}: ${error.message}`;
-      console.error(errorMessage);
-      toast.error(errorMessage);
-      throw error;
+      handleSubmissionError(errorMessage, error);
     }
 
     // TODO: Should take us to all slates view after successful submission
+  }
+
+  function handleSubmissionError(errorMessage, error) {
+    // Reset view
+    setOpenModal(false);
+    setTxsPending(0);
+
+    // Show a message
+    const errorType = handleGenericError(error, toast);
+    if (errorType) {
+      toast.error(`Problem submitting slate: ${errorMessage}`);
+    }
+
+    console.error(error);
   }
 
   return (

--- a/client/utils/transaction.ts
+++ b/client/utils/transaction.ts
@@ -76,10 +76,8 @@ export async function sendAndWaitForTransaction(
         decodedLogs,
         receipt,
       };
-    })
-    .catch((error: any) => {
-      console.log('send tx error:', error);
     });
+  // propagate errors upward to caller
 }
 
 // Submit requestIDs and metadataHash to the Gatekeeper.


### PR DESCRIPTION
Do not rethrow errors in page components. Instead, catch them and handle them by displaying toasts (or whatever is appropriate). Any errors below the page components should be propagated upward to the page rather than simply being caught. Error handling in the pages should reset the view as appropriate and print the error to the console.