### PR TITLE
Add GET and POST endpoints for IPFS data

### DIFF
--- a/api/controllers/ipfs.js
+++ b/api/controllers/ipfs.js
@@ -1,0 +1,37 @@
+const { getFromDatabase, saveToDatabase, add } = require('../utils/ipfs');
+
+
+module.exports = {
+  async getData(req, res) {
+    const { multihash } = req.params;
+    console.log(multihash);
+
+    try {
+      const data = await getFromDatabase(multihash);
+      console.log('DATA', data);
+      if (!data) {
+        return res.status(404).json({ msg: 'Not found' });
+      }
+
+      return res.json(data.data);
+    } catch (error) {
+      return res.status(500).json({ error });
+    }
+  },
+
+  async saveData(req, res) {
+    const data = req.body;
+    // TODO: validate input
+
+    // save to IPFS
+    const multihash = await add(data);
+
+    // TODO: calculate and return the multihash immediately
+
+    // save to database
+    await saveToDatabase(multihash, data);
+    console.log(multihash);
+
+    return res.json(multihash);
+  }
+}

--- a/api/routes.js
+++ b/api/routes.js
@@ -13,6 +13,7 @@ const slate = require('./controllers/slate');
 const ballot = require('./controllers/ballot');
 const notification = require('./controllers/notification');
 const parameter = require('./controllers/parameter');
+const ipfs = require('./controllers/ipfs');
 
 // Routes
 module.exports = app => {
@@ -65,6 +66,10 @@ module.exports = app => {
 
   // NOTIFICATIONS
   app.get('/api/notifications/:address', notification.getByAddress);
+
+  // IPFS
+  app.get('/api/ipfs/:multihash', ipfs.getData);
+  app.post('/api/ipfs', ipfs.saveData);
 
   // PARAMETERS
   app.get('/api/parameters', parameter.getAll);

--- a/api/utils/ipfs.js
+++ b/api/utils/ipfs.js
@@ -7,6 +7,7 @@ const ipfsPort = process.env.IPFS_PORT || 5001;
 
 const ipfs = new IPFS({ host: ipfsHost, port: ipfsPort, protocol: 'https' });
 
+// TODO: move functions to panvala-utils
 /**
  * Get a file from IPFS
  * Options:
@@ -34,6 +35,29 @@ function get(multihash, options) {
       }
     });
   });
+}
+
+/**
+ * Add a file to IPFS and get the CID
+ * @param {Object} obj
+ */
+async function add(obj) {
+  const CID = await new Promise((resolve, reject) => {
+    const data = Buffer.from(JSON.stringify(obj));
+
+    ipfs.add(data, (err, result) => {
+      if (err) reject(new Error(err));
+
+      if (!result) {
+        reject(new Error('Ipfs.get returned undefined.'));
+      }
+      // Returns an array of objects (for each file added) with keys hash, path, size
+      const { hash } = result[0];
+      resolve(hash);
+    });
+  });
+  // console.log('CID:', CID);
+  return CID;
 }
 
 async function findOrSaveIpfsMetadata(metadataHash) {
@@ -64,7 +88,25 @@ async function findOrSaveIpfsMetadata(metadataHash) {
   return metadata;
 }
 
+async function getFromDatabase(multihash) {
+  return IpfsMetadata.findOne({
+    where: {
+      multihash,
+    },
+    raw: true,
+  });
+}
+
+async function saveToDatabase(multihash, data) {
+  return IpfsMetadata.create(
+    { multihash, data }
+  );
+}
+
 module.exports = {
   get,
+  add,
   findOrSaveIpfsMetadata,
+  getFromDatabase,
+  saveToDatabase,
 };


### PR DESCRIPTION
Does not calculate the multihash offline, so it does not yet check if the data has already been stored before storing it on a `POST` request.

- `GET /api/ipfs/:multihash`
- `POST /api/ipfs` (with JSON data)