### PR TITLE
Handle rejection of message signature and catch more errors

### DIFF
--- a/client/pages/Wallet.tsx
+++ b/client/pages/Wallet.tsx
@@ -20,7 +20,7 @@ import { IEthereumContext, EthereumContext } from '../components/EthereumProvide
 import { saveState, loadState, LINKED_WALLETS } from '../utils/localStorage';
 import { splitAddressHumanReadable, isAddress } from '../utils/format';
 import { COLORS } from '../styles';
-import { handleGenericError } from '../utils/errors';
+import { handleGenericError, ETHEREUM_NOT_AVAILABLE } from '../utils/errors';
 
 const CancelButton = styled(Button)`
   color: ${COLORS.grey3};
@@ -153,6 +153,8 @@ const Wallet: React.SFC = () => {
       } catch (error) {
         handleLinkError(error);
       }
+    } else {
+      throw new Error(ETHEREUM_NOT_AVAILABLE);
     }
   }
 

--- a/client/pages/Withdraw.tsx
+++ b/client/pages/Withdraw.tsx
@@ -15,7 +15,7 @@ import { StatelessPage } from '../interfaces';
 import { sendAndWaitForTransaction } from '../utils/transaction';
 import { tsToDeadline } from '../utils/datetime';
 import PendingTransaction from '../components/PendingTransaction';
-import { handleGenericError } from '../utils/errors';
+import { handleGenericError, ETHEREUM_NOT_AVAILABLE } from '../utils/errors';
 
 const CenteredSection = styled.div`
   padding: 2rem;
@@ -73,6 +73,8 @@ const Withdraw: StatelessPage<IProps> = ({ query, asPath }) => {
         setTxPending(false);
         onRefreshBalances();
         onRefreshSlates();
+      } else {
+        throw new Error(ETHEREUM_NOT_AVAILABLE);
       }
     } catch (error) {
       handleWithdrawError(error);

--- a/client/pages/slates/stake.tsx
+++ b/client/pages/slates/stake.tsx
@@ -25,7 +25,7 @@ import { formatPanvalaUnits } from '../../utils/format';
 import { sendApproveTransaction, sendStakeTokensTransaction } from '../../utils/transaction';
 import RouterLink from '../../components/RouterLink';
 
-import { handleGenericError } from '../../utils/errors';
+import { handleGenericError, ETHEREUM_NOT_AVAILABLE } from '../../utils/errors';
 
 const Wrapper = styled.div`
   font-family: 'Roboto';
@@ -79,14 +79,22 @@ const Stake: StatelessPage<any> = ({ query, classes }) => {
     }
   }, [slatesByID, slate.requiredStake]);
 
+  function checkAccount() {
+    if (!account) {
+      throw new Error(ETHEREUM_NOT_AVAILABLE);
+    }
+  }
+
   // step 1: approve
   async function handleApproveTokens() {
-    if (!account || approved) {
-      console.log('no account or already approved');
-      return false;
-    }
-
     try {
+      checkAccount();
+
+      if (approved) {
+        console.log('already approved');
+        return false;
+      }
+
       if (contracts) {
         // send tx (pending)
         setTxPending(true);
@@ -113,10 +121,12 @@ const Stake: StatelessPage<any> = ({ query, classes }) => {
   // step 2: stakeTokens
   async function handleStakeTokens() {
     try {
+      checkAccount();
+
       // check (again) if the user has approved the gatekeeper for the slate staking requirement
       const isApproved: boolean = gkAllowance.gte(slate.requiredStake);
-      if (!account || !isApproved) {
-        console.log('no account or not approved');
+      if (!isApproved) {
+        console.log('not approved');
         return false;
       }
 

--- a/client/utils/errors.ts
+++ b/client/utils/errors.ts
@@ -52,6 +52,8 @@ export enum PanvalaError {
   Unknown,
 }
 
+export const ETHEREUM_NOT_AVAILABLE = 'Ethereum not available';
+
 /**
  * Try to handle the error generically. Return a PanvalaError if the error isn't handled.
  */
@@ -87,6 +89,11 @@ function checkError(error: Error): PanvalaError {
 
       // revert
     }
+  } else if (msg.includes('Ethereum not available')) {
+    return PanvalaError.NotLoggedIn;
+  } else if (msg.includes('unknown account')) {
+    // from ethers
+    return PanvalaError.NotLoggedIn;
   }
 
   // TODO:


### PR DESCRIPTION
Add `PanvalaError.SignatureRejected` and handle that case in `handleGenericError()`. Remove the toast in the `else` case, because the caller should handle whether to show a toast and what message to show. This fixes the issue where two toasts were showing when the user rejected the signature during voting.

Wrap more logic in the try/catch blocks and re-throw when necessary. Handle cases where account or contracts are not defined by asking the user to log in to MetaMask.