### PR TITLE
Fix issues connecting to provider on mobile

### DIFF
--- a/website/build/root.js
+++ b/website/build/root.js
@@ -55,13 +55,15 @@ class Root extends React.Component {
         _this.setState({
           error: 'Buffer did not setup correctly.'
         });
-      } // Listen for network changes -> reload page
+      }
 
-
-      window.ethereum.once('networkChanged', network => {
-        console.log('MetaMask network changed:', network);
-        window.location.reload();
-      });
+      if (typeof window !== 'undefined' && window.hasOwnProperty('ethereum')) {
+        // Listen for network changes -> reload page
+        window.ethereum.on('networkChanged', network => {
+          console.log('MetaMask network changed:', network);
+          window.location.reload();
+        });
+      }
     })();
   } // Setup provider & selected account
 

--- a/website/src/root.js
+++ b/website/src/root.js
@@ -38,11 +38,13 @@ class Root extends React.Component {
       this.setState({ error: 'Buffer did not setup correctly.' });
     }
 
-    // Listen for network changes -> reload page
-    window.ethereum.once('networkChanged', network => {
-      console.log('MetaMask network changed:', network);
-      window.location.reload();
-    });
+    if (typeof window !== 'undefined' && window.hasOwnProperty('ethereum')) {
+      // Listen for network changes -> reload page
+      window.ethereum.on('networkChanged', network => {
+        console.log('MetaMask network changed:', network);
+        window.location.reload();
+      });
+    }
   }
 
   // Setup provider & selected account


### PR DESCRIPTION
Use `provider.on()` instead of `provider.once()` for handling network and account changes. Mobile browsers do not seem to implement the latter (and are not required to in EIP-1193).

- Refactor EthereumProvider component
- Update website root component