### PR TITLE
Add API endpoint /api/token/circulating-supply

### DIFF
--- a/api/controllers/token.js
+++ b/api/controllers/token.js
@@ -1,0 +1,19 @@
+const ethers = require('ethers');
+const { formatUnits } = ethers.utils;
+
+const { circulatingSupply } = require('../utils/token');
+
+async function circulating(req, res) {
+  return circulatingSupply()
+    .then(supply => formatUnits(supply, '18'))
+    .then(value => res.send(value))
+    .catch(error => {
+      console.error(error);
+      const msg = `Error getting circulating supply: ${error.message}`;
+      return res.status(500).send(msg);
+    });
+}
+
+module.exports = {
+  circulatingSupply: circulating,
+};

--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,7 @@
     "migrate:undo": "sequelize db:migrate:undo",
     "create-migration": "sequelize migration:generate --name",
     "sync-events": "node scripts/sync-contract-events.js",
-    "test": "jest --passWithNoTests"
+    "test": "jest"
   },
   "author": "",
   "license": "ISC",

--- a/api/routes.js
+++ b/api/routes.js
@@ -15,6 +15,7 @@ const notification = require('./controllers/notification');
 const parameter = require('./controllers/parameter');
 const ipfs = require('./controllers/ipfs');
 const website = require('./controllers/website');
+const token = require('./controllers/token');
 
 // Routes
 module.exports = app => {
@@ -77,4 +78,7 @@ module.exports = app => {
 
   // Website
   app.post('/api/website', website.addContact);
+
+  // Token
+  app.get('/api/token/circulating-supply', token.circulatingSupply);
 };

--- a/api/test/token.test.js
+++ b/api/test/token.test.js
@@ -1,0 +1,14 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('circulatingSupply', () => {
+  const route = '/api/token/circulating-supply';
+
+  // SKIP - we can't actually run this without an Ethereum provider
+  test.skip('it should calculate the circulating supply', async () => {
+    const totalSupply = 100000000;
+
+    const result = await request(app).get(route);
+    expect(result.status).toBe(200);
+  });
+});

--- a/api/utils/eth.js
+++ b/api/utils/eth.js
@@ -5,9 +5,8 @@ const {
   contracts: { gatekeeperAddress, tokenCapacitorAddress },
 } = config;
 
-const {
-  contractABIs: { Gatekeeper, TokenCapacitor, ParameterStore },
-} = require('../../packages/panvala-utils');
+const { contractABIs } = require('.');
+const { Gatekeeper, TokenCapacitor, ParameterStore } = contractABIs;
 
 /**
  * Check connection
@@ -48,4 +47,5 @@ async function getContracts() {
 module.exports = {
   checkConnection,
   getContracts,
+  contractABIs,
 };

--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -1,0 +1,7 @@
+const panvala_utils = require('../../packages/panvala-utils');
+
+const modules = { ...panvala_utils };
+
+module.exports = {
+  ...modules,
+};

--- a/api/utils/token.js
+++ b/api/utils/token.js
@@ -1,0 +1,79 @@
+const ethers = require('ethers');
+const { getContracts, contractABIs } = require('./eth');
+const { timing } = require('.');
+
+const { bigNumberify: BN, parseUnits } = ethers.utils;
+const { BasicToken: Token } = contractABIs;
+
+const zero = BN(0);
+const asTokens = amount => parseUnits(amount, '18');
+
+function linearDecay(total, start, end, x) {
+  const _end = BN(end);
+  const _x = BN(x);
+  const num = BN(total).mul(_end.sub(_x));
+  const den = _end.sub(BN(start));
+  return num.div(den);
+}
+
+function calculateCirculatingSupply(params) {
+  const {
+    totalSupply,
+    now,
+    vestingStart,
+    vestingEnd,
+    initialVestedTokens,
+    launchPartnerFundBalance,
+    tokenCapacitorLockedBalance,
+  } = params;
+
+  const unvestedTokens =
+    now < vestingStart
+      ? initialVestedTokens
+      : now > vestingEnd
+      ? zero
+      : linearDecay(initialVestedTokens, vestingStart, vestingEnd, now);
+
+  const totalLocked = launchPartnerFundBalance.add(tokenCapacitorLockedBalance).add(unvestedTokens);
+  return totalSupply.sub(totalLocked);
+}
+
+// Return the current circulating supply of PAN
+async function circulatingSupply() {
+  // contracts
+  const { tokenCapacitor, provider } = await getContracts();
+  const tokenAddress = await tokenCapacitor.token();
+  const token = new ethers.Contract(tokenAddress, Token.abi, provider);
+  const launchPartnerFundAddress = '0x171dcDE3AC66a6DbED0FaC5e1d53132145520302';
+
+  // vesting -- all vesting happens at the same rate, so we can treat all the vesting
+  // contracts as a single one with the balance of all of them
+  const vestingStart = 1572627600; // 2019-11-01T17:00:00.000Z
+  const vestingDurationDays = 730;
+  const vestingEnd = vestingStart + vestingDurationDays * timing.durations.ONE_DAY;
+  const initialVestedTokens = asTokens('27406303');
+
+  // balances
+  const totalSupply = await token.totalSupply();
+  const launchPartnerFundBalance = await token.balanceOf(launchPartnerFundAddress);
+  const tokenCapacitorLockedBalance = await tokenCapacitor.lastLockedBalance();
+
+  const now = Math.floor(new Date() / 1000);
+
+  return calculateCirculatingSupply({
+    now,
+    vestingStart,
+    vestingEnd,
+    initialVestedTokens,
+    launchPartnerFundBalance,
+    tokenCapacitorLockedBalance,
+    totalSupply,
+  });
+}
+
+module.exports = {
+  linearDecay,
+  calculateCirculatingSupply,
+  circulatingSupply,
+  asTokens,
+};

--- a/api/utils/token.js
+++ b/api/utils/token.js
@@ -22,17 +22,17 @@ function calculateCirculatingSupply(params) {
     now,
     vestingStart,
     vestingEnd,
-    initialVestedTokens,
+    initialUnvestedTokens,
     launchPartnerFundBalance,
     tokenCapacitorLockedBalance,
   } = params;
 
   const unvestedTokens =
     now < vestingStart
-      ? initialVestedTokens
+      ? initialUnvestedTokens
       : now > vestingEnd
       ? zero
-      : linearDecay(initialVestedTokens, vestingStart, vestingEnd, now);
+      : linearDecay(initialUnvestedTokens, vestingStart, vestingEnd, now);
 
   const totalLocked = launchPartnerFundBalance.add(tokenCapacitorLockedBalance).add(unvestedTokens);
   return totalSupply.sub(totalLocked);
@@ -51,7 +51,7 @@ async function circulatingSupply() {
   const vestingStart = 1572627600; // 2019-11-01T17:00:00.000Z
   const vestingDurationDays = 730;
   const vestingEnd = vestingStart + vestingDurationDays * timing.durations.ONE_DAY;
-  const initialVestedTokens = asTokens('27406303');
+  const initialUnvestedTokens = asTokens('27406303');
 
   // balances
   const totalSupply = await token.totalSupply();
@@ -64,7 +64,7 @@ async function circulatingSupply() {
     now,
     vestingStart,
     vestingEnd,
-    initialVestedTokens,
+    initialUnvestedTokens,
     launchPartnerFundBalance,
     tokenCapacitorLockedBalance,
     totalSupply,

--- a/api/utils/token.test.js
+++ b/api/utils/token.test.js
@@ -30,19 +30,19 @@ describe('calculateCirculatingSupply', () => {
   const vestingStart = 1572627600; // 2019-11-01T17:00:00.000Z
   const vestingDurationDays = 730;
   const vestingEnd = vestingStart + vestingDurationDays * timing.durations.ONE_DAY;
-  const initialVestedTokens = asTokens('27406303');
+  const initialUnvestedTokens = asTokens('27406303');
   const launchPartnerFundBalance = asTokens('10000000');
   const tokenCapacitorLockedBalance = asTokens('20000000');
   const totalSupply = asTokens('100000000');
 
-  const initialLocked = initialVestedTokens
+  const initialLocked = initialUnvestedTokens
     .add(launchPartnerFundBalance)
     .add(tokenCapacitorLockedBalance);
 
   const params = {
     vestingStart,
     vestingEnd,
-    initialVestedTokens,
+    initialUnvestedTokens,
     launchPartnerFundBalance,
     tokenCapacitorLockedBalance,
     totalSupply,

--- a/api/utils/token.test.js
+++ b/api/utils/token.test.js
@@ -1,0 +1,100 @@
+const { parseUnits } = require('ethers').utils;
+const { timing } = require('.');
+const { linearDecay, calculateCirculatingSupply, asTokens } = require('./token');
+
+describe('linearDecay', () => {
+  const initial = 10000;
+  const start = 200;
+  const end = 1200;
+
+  test('it should return the full amount at the start', () => {
+    const now = start;
+    const left = linearDecay(initial, start, end, now);
+    expect(left.toString()).toBe(initial.toString());
+  });
+
+  test('it should return 0 at the end', () => {
+    const now = end;
+    const left = linearDecay(initial, start, end, now);
+    expect(left.toString()).toBe('0');
+  });
+
+  test('it should return half at the midpoint', () => {
+    const now = (end + start) / 2;
+    const left = linearDecay(initial, start, end, now);
+    expect(left.toString()).toBe('5000');
+  });
+});
+
+describe('calculateCirculatingSupply', () => {
+  const vestingStart = 1572627600; // 2019-11-01T17:00:00.000Z
+  const vestingDurationDays = 730;
+  const vestingEnd = vestingStart + vestingDurationDays * timing.durations.ONE_DAY;
+  const initialVestedTokens = asTokens('27406303');
+  const launchPartnerFundBalance = asTokens('10000000');
+  const tokenCapacitorLockedBalance = asTokens('20000000');
+  const totalSupply = asTokens('100000000');
+
+  const initialLocked = initialVestedTokens
+    .add(launchPartnerFundBalance)
+    .add(tokenCapacitorLockedBalance);
+
+  const params = {
+    vestingStart,
+    vestingEnd,
+    initialVestedTokens,
+    launchPartnerFundBalance,
+    tokenCapacitorLockedBalance,
+    totalSupply,
+  };
+
+  const initialCirculating = totalSupply.sub(initialLocked);
+  const finalLocked = launchPartnerFundBalance.add(tokenCapacitorLockedBalance);
+  const finalCirculating = totalSupply.sub(finalLocked);
+
+  test('it should return the initial amount before vesting starts', () => {
+    const supply = calculateCirculatingSupply({
+      ...params,
+      now: vestingStart - 1000,
+    });
+
+    expect(supply.toString()).toBe(initialCirculating.toString());
+  });
+
+  test('it should return the initial amount at the start of the vesting period', () => {
+    const supply = calculateCirculatingSupply({
+      ...params,
+      now: vestingStart,
+    });
+
+    expect(supply.toString()).toBe(initialCirculating.toString());
+  });
+
+  test('it should return an intermediate amount in the middle of the vesting period', () => {
+    const supply = calculateCirculatingSupply({
+      ...params,
+      now: (vestingStart + vestingEnd) / 2,
+    });
+
+    expect(supply.gt(initialCirculating)).toBe(true);
+    expect(supply.lt(finalCirculating)).toBe(true);
+  });
+
+  test('it should include all the vested tokens at the end of the vesting period', () => {
+    const supply = calculateCirculatingSupply({
+      ...params,
+      now: vestingEnd,
+    });
+
+    expect(supply.toString()).toBe(finalCirculating.toString());
+  });
+
+  test('it should include all the vested tokens after the end of the vesting period', () => {
+    const supply = calculateCirculatingSupply({
+      ...params,
+      now: vestingEnd + 1000,
+    });
+
+    expect(supply.toString()).toBe(finalCirculating.toString());
+  });
+});


### PR DESCRIPTION
Add a function to calculate the circulating supply of PAN based on the total supply excluding the balance of the launch partner token capacitor, the locked balance of the grants token capacitor, and the remaining unvested tokens. Expose it at the endpoint `/api/token/circulating-supply`.