### PR TITLE
Display governance slate details and update metadata

### DIFF
--- a/api/utils/ipfs.js
+++ b/api/utils/ipfs.js
@@ -109,15 +109,19 @@ async function calculateMultihash(obj) {
   const CID = await new Promise((resolve, reject) => {
     const data = Buffer.from(JSON.stringify(obj));
 
-    ipfs.add(data, { 'only-hash': true }, (err, result) => {
-      if (err) reject(new Error(err));
-
-      if (!result) {
-        reject(new Error('Ipfs.get returned undefined.'));
+    return ipfs.add(data, { 'only-hash': true }, (err, result) => {
+      if (err) {
+        const msg = `IPFS add: ${err.message}`;
+        reject(new Error(msg));
       }
-      // Returns an array of objects (for each file added) with keys hash, path, size
-      const { hash } = result[0];
-      resolve(hash);
+
+      try {
+        // Returns an array of objects (for each file added) with keys hash, path, size
+        const { hash } = result[0];
+        resolve(hash);
+      } catch (error) {
+        reject(new Error(`IPFS add: ${error.message}`));
+      }
     });
   });
   return CID;

--- a/api/utils/ipfs.js
+++ b/api/utils/ipfs.js
@@ -49,6 +49,7 @@ async function add(obj) {
       if (err) {
         const msg = `IPFS add: ${err.message}`;
         reject(new Error(msg));
+        return;
       }
 
       try {
@@ -113,6 +114,7 @@ async function calculateMultihash(obj) {
       if (err) {
         const msg = `IPFS add: ${err.message}`;
         reject(new Error(msg));
+        return;
       }
 
       try {

--- a/api/utils/ipfs.js
+++ b/api/utils/ipfs.js
@@ -45,15 +45,19 @@ async function add(obj) {
   const CID = await new Promise((resolve, reject) => {
     const data = Buffer.from(JSON.stringify(obj));
 
-    ipfs.add(data, (err, result) => {
-      if (err) reject(new Error(err));
-
-      if (!result) {
-        reject(new Error('Ipfs.get returned undefined.'));
+    return ipfs.add(data, (err, result) => {
+      if (err) {
+        const msg = `IPFS add: ${err.message}`;
+        reject(new Error(msg));
       }
-      // Returns an array of objects (for each file added) with keys hash, path, size
-      const { hash } = result[0];
-      resolve(hash);
+
+      try {
+        // Returns an array of objects (for each file added) with keys hash, path, size
+        const { hash } = result[0];
+        resolve(hash);
+      } catch (error) {
+        reject(new Error(`IPFS add: ${error.message}`));
+      }
     });
   });
   // console.log('CID:', CID);
@@ -98,16 +102,14 @@ async function getFromDatabase(multihash) {
 }
 
 async function saveToDatabase(multihash, data) {
-  return IpfsMetadata.create(
-    { multihash, data }
-  );
+  return IpfsMetadata.create({ multihash, data });
 }
 
 async function calculateMultihash(obj) {
   const CID = await new Promise((resolve, reject) => {
     const data = Buffer.from(JSON.stringify(obj));
 
-    ipfs.add(data, {"only-hash": true}, (err, result) => {
+    ipfs.add(data, { 'only-hash': true }, (err, result) => {
       if (err) reject(new Error(err));
 
       if (!result) {

--- a/api/utils/requests.js
+++ b/api/utils/requests.js
@@ -1,5 +1,7 @@
-const { Request } = require('../models');
+const { Request, Sequelize } = require('../models');
 const { getAllSlates } = require('./slates');
+
+const { in: opIn } = Sequelize.Op;
 
 // workaround for now. we should really be caching events and getting them from the db
 async function mapRequestsToProposals(events, gatekeeper) {
@@ -38,6 +40,21 @@ async function mapRequestsToProposals(events, gatekeeper) {
   );
 }
 
+// Find proposals matching the given resource and request IDs
+async function getProposalsForRequests(resource, requestIDs) {
+  if (requestIDs.length === 0) return Promise.resolve([]);
+
+  const where = { resource };
+  where['requestID'] = {
+    [opIn]: requestIDs,
+  };
+
+  return Request.findAll({
+    where,
+  });
+}
+
 module.exports = {
   mapRequestsToProposals,
+  getProposalsForRequests,
 };

--- a/api/utils/slates.js
+++ b/api/utils/slates.js
@@ -214,11 +214,11 @@ async function normalizeMetadata(slateMetadata, resource) {
     const proposals = await Promise.all(
       rawProposals.map(p => {
         const { metadataHash } = p;
+        // TODO: handle empty oldValue
         return ipfs.findOrSaveIpfsMetadata(metadataHash).then(metadata => {
           const { parameterChanges } = metadata.data;
           return {
-            ...parameterChanges,
-            metadataHash: toUtf8String(metadataHash),
+            parameterChanges,
           };
         });
       })

--- a/api/utils/slates.js
+++ b/api/utils/slates.js
@@ -164,7 +164,7 @@ async function getSlateWithMetadata(slateID, slate, metadataHash, incumbent, req
       category,
       epochNumber: slate.epochNumber.toNumber(),
       incumbent,
-      description: description || slateMetadata.summary,
+      description,
       metadataHash,
       organization,
       // either first + last name or just first name
@@ -204,8 +204,6 @@ async function normalizeMetadata(slateMetadata, resource) {
 
   // is governance v1 - has `resource` and `requestIDs` keys (and summary instead of description)
   if (slateMetadata.resource != null && requestIDs != null) {
-    // console.log('REQUESTS', requestIDs);
-
     // get the associated proposals from the database
     const rawProposals = await getProposalsForRequests(resource, requestIDs);
     const multihashes = rawProposals.map(p => toUtf8String(p.metadataHash));

--- a/client/components/ParametersForm.tsx
+++ b/client/components/ParametersForm.tsx
@@ -98,7 +98,7 @@ const ParametersForm: React.SFC<any> = props => {
           />
         ))}
         {/* display errors global to the parameters form */}
-        {errors.parametersForm ? (
+        {errors && errors.parametersForm ? (
           <CustomErrorMessage>{errors.parametersForm}</CustomErrorMessage>
         ) : null}
       </Flex>

--- a/client/components/ParametersForm.tsx
+++ b/client/components/ParametersForm.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import Flex, { BreakableFlex } from './system/Flex';
-import { formatPanvalaUnits } from '../utils/format';
+import { formatPanvalaUnits, parameterDisplayName } from '../utils/format';
 import FieldInput from '../components/FieldInput';
 
 const CustomErrorMessage = styled.span`
@@ -12,7 +12,7 @@ const CustomErrorMessage = styled.span`
   color: red;
 `;
 
-export interface IParameterFormProps {
+export interface IParameterRowProps {
   parameterName: string;
   name: string;
   displayValue: string;
@@ -55,21 +55,20 @@ const ParameterRow: React.SFC<any> = props => {
   );
 };
 
-
 const ParametersForm: React.SFC<any> = props => {
   const { errors, parameters } = props;
 
   // Transform the parameter data into the right shape for the form
-  const rowData: IParameterFormProps[] = Object.keys(parameters).map(k => {
-    const { parameterName, key, newValue, oldValue, type } = parameters[k];
+  const rowData: IParameterRowProps[] = Object.keys(parameters).map(k => {
+    const { key, newValue, oldValue, type } = parameters[k];
     return {
-      parameterName,
+      parameterName: parameterDisplayName(key),
       name: `parameters.${key}.newValue`,
       displayValue: type === 'uint256' ? formatPanvalaUnits(oldValue) : oldValue,
       oldValue,
       newValue,
       type: type === 'uint256' ? 'Number' : 'Address',
-    }
+    };
   });
 
   return (

--- a/client/components/stories/ParametersForm.stories.tsx
+++ b/client/components/stories/ParametersForm.stories.tsx
@@ -7,14 +7,12 @@ import { StoryWrapper } from './utils.stories';
 
 const parameters = {
   slateStakeAmount: {
-    parameterName: 'Slate Stake Amount',
     oldValue: '5000000000000000000000',
     newValue: '',
     type: 'uint256',
     key: 'slateStakeAmount',
   },
   gatekeeperAddress: {
-    parameterName: 'Gatekeeper Address',
     oldValue: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     newValue: '',
     type: 'address',

--- a/client/components/stories/ParametersForm.stories.tsx
+++ b/client/components/stories/ParametersForm.stories.tsx
@@ -1,20 +1,44 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
+import { Form, Formik } from 'formik';
 import ParametersForm from '../ParametersForm';
 import Box from '../system/Box';
 import { StoryWrapper } from './utils.stories';
 
+const parameters = {
+  slateStakeAmount: {
+    parameterName: 'Slate Stake Amount',
+    oldValue: '5000000000000000000000',
+    newValue: '',
+    type: 'uint256',
+    key: 'slateStakeAmount',
+  },
+  gatekeeperAddress: {
+    parameterName: 'Gatekeeper Address',
+    oldValue: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    newValue: '',
+    type: 'address',
+    key: 'gatekeeperAddress',
+  },
+};
+
+const noop = () => {};
+
 storiesOf('ParametersForm', module).add('ParametersForm', () => (
   <StoryWrapper>
     <Box width="620px">
-      <ParametersForm
-        onChange={(name: string, value: any) => {
-          console.log('name, value:', name, value);
-        }}
-        slateStakeAmount={'5000.0 PAN'}
-        newSlateStakeAmount={''}
-        newTokenAddress={''}
-      />
+      <Formik initialValues={parameters} onSubmit={noop}>
+        {() => (
+          <Form>
+            <ParametersForm
+              onChange={(name: string, value: any) => {
+                console.log('name, value:', name, value);
+              }}
+              parameters={parameters}
+            />
+          </Form>
+        )}
+      </Formik>
     </Box>
   </StoryWrapper>
 ));

--- a/client/components/stories/Slate.stories.tsx
+++ b/client/components/stories/Slate.stories.tsx
@@ -17,6 +17,8 @@ import {
   rejectedGovSlate,
   acceptedGovSlate,
   proposals,
+  governanceProposals,
+  governanceSlate,
 } from './data';
 import { SlateStatus } from '../../utils/status';
 import { convertedToBaseUnits } from '../../utils/format';
@@ -122,7 +124,12 @@ storiesOf('Slate', module)
         <Slate query={{ id: '0' }} />
       </StoryWrapper>
     );
-  });
+  })
+  .add('governance', () => (
+    <StoryWrapper slates={[governanceSlate]} proposals={governanceProposals}>
+      <Slate query={{id: governanceSlate.id }} />
+    </StoryWrapper>
+  ));
 
 const ballot = makeBallot();
 

--- a/client/components/stories/data.ts
+++ b/client/components/stories/data.ts
@@ -3,8 +3,9 @@ import range from 'lodash/range';
 import uuid from 'uuid/v4';
 import { utils } from 'ethers';
 import { ballotDates } from '../../utils/voting';
-import { ISlate, IProposal } from '../../interfaces';
+import { ISlate, IProposal, IGovernanceProposal } from '../../interfaces';
 import '../../globalStyles.css';
+import { SlateStatus } from '../../utils/status';
 
 // https://github.com/zeit/next.js/issues/1827#issuecomment-323314141
 (Router as any).router = {
@@ -56,6 +57,31 @@ export const unstakedSlate: ISlate = {
   epochNumber: 1,
 };
 
+export const governanceProposals: IGovernanceProposal[] = [
+  {
+    key: 'slateStakeAmount',
+    oldValue: '50000000000000000000000',
+    newValue: '45000000000000000000000',
+    type: 'uint256',
+    metadataHash: 'QmQVxAnYdA3n7sCSkyGNrX3JK4pF5ewsnoym3NFDZ8PrzV',
+  },
+  {
+    key: 'gatekeeperAddress',
+    oldValue: '0xd115bffabbdd893a6f7cea402e7338643ced44a6',
+    newValue: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    type: 'address',
+    metadataHash: 'QmQVxAnYdA3n7sCSkyGNrX3JK4pF5ewsnoym3NFDZ8PrzV',
+  },
+  {
+    key: 'stakeDonationAddress',
+    oldValue: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    newValue: '0xffffffffffffffffffffffffffffffffffffffff',
+    type: 'address',
+    metadataHash: 'QmQVxAnYdA3n7sCSkyGNrX3JK4pF5ewsnoym3NFDZ8PrzV',
+  }
+];
+
+
 export function makeBallot(options?: any, prototype?: any) {
   return {
     ...baseBallot,
@@ -105,3 +131,10 @@ export const rejectedGovSlate = makeSlate(
   },
   acceptedGovSlate
 );
+
+export const governanceSlate = {
+  ...acceptedGovSlate,
+  id: 0,
+  status: SlateStatus.Staked,
+  proposals: governanceProposals,
+};

--- a/client/components/stories/data.ts
+++ b/client/components/stories/data.ts
@@ -59,25 +59,28 @@ export const unstakedSlate: ISlate = {
 
 export const governanceProposals: IGovernanceProposal[] = [
   {
-    key: 'slateStakeAmount',
-    oldValue: '50000000000000000000000',
-    newValue: '45000000000000000000000',
-    type: 'uint256',
-    metadataHash: 'QmQVxAnYdA3n7sCSkyGNrX3JK4pF5ewsnoym3NFDZ8PrzV',
+    parameterChanges: {
+      key: 'slateStakeAmount',
+      oldValue: '50000000000000000000000',
+      newValue: '45000000000000000000000',
+      type: 'uint256',
+    }
   },
   {
-    key: 'gatekeeperAddress',
-    oldValue: '0xd115bffabbdd893a6f7cea402e7338643ced44a6',
-    newValue: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-    type: 'address',
-    metadataHash: 'QmQVxAnYdA3n7sCSkyGNrX3JK4pF5ewsnoym3NFDZ8PrzV',
+    parameterChanges: {
+      key: 'gatekeeperAddress',
+      oldValue: '0xd115bffabbdd893a6f7cea402e7338643ced44a6',
+      newValue: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      type: 'address',
+    }
   },
   {
-    key: 'stakeDonationAddress',
-    oldValue: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-    newValue: '0xffffffffffffffffffffffffffffffffffffffff',
-    type: 'address',
-    metadataHash: 'QmQVxAnYdA3n7sCSkyGNrX3JK4pF5ewsnoym3NFDZ8PrzV',
+    parameterChanges: {
+      key: 'stakeDonationAddress',
+      oldValue: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      newValue: '0xffffffffffffffffffffffffffffffffffffffff',
+      type: 'address',
+    }
   }
 ];
 

--- a/client/interfaces/index.ts
+++ b/client/interfaces/index.ts
@@ -12,6 +12,7 @@ import {
 import { ISlate, ISlateMetadata, ISaveSlate, IGovernanceSlateFormValues } from './slates';
 import { IChoices, ISubmitBallot, IBallotDates } from './voting';
 
+export { IGovernanceProposal } from './proposals';
 export {
   ISlate,
   IProposal,

--- a/client/interfaces/proposals.ts
+++ b/client/interfaces/proposals.ts
@@ -55,11 +55,12 @@ export interface IParameterChangesObject {
 
 // Rendered in the frontend
 export interface IGovernanceProposal {
-  oldValue: any;
-  newValue: any;
-  type: any;
-  key: any;
-  metadataHash: string;
+  parameterChanges: {
+    oldValue: any;
+    newValue: any;
+    type: any;
+    key: any;
+  }
 }
 
 // Saved to IPFS

--- a/client/interfaces/proposals.ts
+++ b/client/interfaces/proposals.ts
@@ -62,8 +62,8 @@ export interface IGovernanceProposal {
   metadataHash: string;
 }
 
+// Saved to IPFS
 export interface IGovernanceProposalMetadata {
-  id: number;
   firstName: string;
   lastName?: string;
   summary: string;

--- a/client/interfaces/proposals.ts
+++ b/client/interfaces/proposals.ts
@@ -53,6 +53,15 @@ export interface IParameterChangesObject {
   };
 }
 
+// Rendered in the frontend
+export interface IGovernanceProposal {
+  oldValue: any;
+  newValue: any;
+  type: any;
+  key: any;
+  metadataHash: string;
+}
+
 export interface IGovernanceProposalMetadata {
   id: number;
   firstName: string;

--- a/client/pages/Parameters.tsx
+++ b/client/pages/Parameters.tsx
@@ -5,7 +5,7 @@ import Button from '../components/Button';
 import RouterLink from '../components/RouterLink';
 import Text from '../components/system/Text';
 import { EthereumContext } from '../components/EthereumProvider';
-import { formatPanvalaUnits } from '../utils/format';
+import { formatPanvalaUnits, parameterDisplayName } from '../utils/format';
 
 const ParameterRow: React.SFC<any> = props => {
   return (
@@ -36,11 +36,13 @@ const Parameters: React.FC = () => {
 
   const parameters = [
     {
-      name: 'Slate Stake Amount',
+      key: 'slateStakeAmount',
+      name: parameterDisplayName('slateStakeAmount'),
       value: formatPanvalaUnits(slateStakeAmount),
     },
     {
-      name: 'Gatekeeper Address',
+      key: 'gatekeeperAddress',
+      name: parameterDisplayName('gatekeeperAddress'),
       value: gatekeeper.address,
     },
   ];
@@ -70,7 +72,7 @@ const Parameters: React.FC = () => {
           </Flex>
         </Flex>
         {parameters.map(p => (
-          <ParameterRow key={p.name} parameterName="Required Stake" name={p.name} value={p.value} />
+          <ParameterRow key={p.key} name={p.name} value={p.value} />
         ))}
       </Flex>
     </>

--- a/client/pages/slates/create/governance.tsx
+++ b/client/pages/slates/create/governance.tsx
@@ -64,7 +64,6 @@ interface IGovernanceSlateMetadataV1 {
   resource: string;
 }
 
-
 // Match the general slate metadata format
 interface IGovernanceSlateMetadataV2 extends ISlateMetadata {}
 
@@ -89,14 +88,12 @@ const CreateGovernanceSlate: StatelessPage<any> = () => {
   // parameters
   const initialParameters = {
     slateStakeAmount: {
-      parameterName: 'Slate Stake Amount',
       oldValue: slateStakeAmount.toString(),
       newValue: '',
       type: 'uint256',
       key: 'slateStakeAmount',
     },
     gatekeeperAddress: {
-      parameterName: 'Gatekeeper Address',
       oldValue: contracts.gatekeeper.address,
       newValue: '',
       type: 'address',
@@ -195,22 +192,24 @@ const CreateGovernanceSlate: StatelessPage<any> = () => {
 
       const paramKeys = Object.keys(parameterChanges);
 
-      const proposalMetadatas: IGovernanceProposalMetadata[] = paramKeys.map((param: string): IGovernanceProposalMetadata => {
-        const { oldValue, newValue, type, key } = parameterChanges[param];
+      const proposalMetadatas: IGovernanceProposalMetadata[] = paramKeys.map(
+        (param: string): IGovernanceProposalMetadata => {
+          const { oldValue, newValue, type, key } = parameterChanges[param];
 
-        return {
-          firstName: values.firstName,
-          lastName: values.lastName,
-          summary: values.summary,
-          organization: values.organization,
-          parameterChanges: {
-            key,
-            oldValue,
-            newValue,
-            type,
-          },
-        };
-      });
+          return {
+            firstName: values.firstName,
+            lastName: values.lastName,
+            summary: values.summary,
+            organization: values.organization,
+            parameterChanges: {
+              key,
+              oldValue,
+              newValue,
+              type,
+            },
+          };
+        }
+      );
 
       const proposalMultihashes: Buffer[] = await Promise.all(
         proposalMetadatas.map(async (metadata: IGovernanceProposalMetadata) => {
@@ -374,7 +373,10 @@ const CreateGovernanceSlate: StatelessPage<any> = () => {
               try {
                 const changes: IParameterChangesObject = filterParameterChanges(values.parameters);
                 if (Object.keys(changes).length === 0) {
-                  setFieldError('parametersForm', 'You must enter some parameter values different from the old ones');
+                  setFieldError(
+                    'parametersForm',
+                    'You must enter some parameter values different from the old ones'
+                  );
                 } else {
                   await handleSubmitSlate(values, changes);
                 }

--- a/client/pages/slates/create/governance.tsx
+++ b/client/pages/slates/create/governance.tsx
@@ -23,9 +23,8 @@ import { ErrorMessage } from '../../../components/FormError';
 import Modal, { ModalTitle, ModalDescription } from '../../../components/Modal';
 import { Separator } from '../../../components/Separator';
 import SectionLabel from '../../../components/SectionLabel';
-import { convertedToBaseUnits, formatPanvalaUnits } from '../../../utils/format';
-import { ipfsAddObject } from '../../../utils/ipfs';
-import { postSlate } from '../../../utils/api';
+import { convertedToBaseUnits, formatPanvalaUnits, getAddress } from '../../../utils/format';
+import { postSlate, saveToIpfs } from '../../../utils/api';
 import { handleGenericError, ETHEREUM_NOT_AVAILABLE } from '../../../utils/errors';
 import {
   ISaveSlate,
@@ -65,6 +64,10 @@ interface IGovernanceSlateMetadataV1 {
   resource: string;
 }
 
+
+// Match the general slate metadata format
+interface IGovernanceSlateMetadataV2 extends ISlateMetadata {}
+
 const CreateGovernanceSlate: StatelessPage<any> = () => {
   // modal opener
   const [isOpen, setOpenModal] = React.useState(false);
@@ -82,6 +85,24 @@ const CreateGovernanceSlate: StatelessPage<any> = () => {
   const [pendingText, setPendingText] = React.useState('');
   const [pageStatus, setPageStatus] = React.useState(PageStatus.Loading);
   const [deadline, setDeadline] = React.useState(0);
+
+  // parameters
+  const initialParameters = {
+    slateStakeAmount: {
+      parameterName: 'Slate Stake Amount',
+      oldValue: slateStakeAmount.toString(),
+      newValue: '',
+      type: 'uint256',
+      key: 'slateStakeAmount',
+    },
+    gatekeeperAddress: {
+      parameterName: 'Gatekeeper Address',
+      oldValue: contracts.gatekeeper.address,
+      newValue: '',
+      type: 'address',
+      key: 'gatekeeperAddress',
+    },
+  };
 
   // Update page status when ballot info changes
   React.useEffect(() => {
@@ -130,18 +151,26 @@ const CreateGovernanceSlate: StatelessPage<any> = () => {
   ): IParameterChangesObject {
     return Object.keys(formParameters).reduce((acc, paramKey) => {
       let value = clone(formParameters[paramKey]);
-      if (!!value.newValue && value.newValue !== value.oldValue) {
+      if (!!value.newValue) {
+        // Convert values if necessary first before checking equality
         if (paramKey === 'slateStakeAmount') {
+          // Convert token amount
           value.newValue = convertedToBaseUnits(value.newValue, 18);
-        } else if (paramKey === 'gatekeeperAddress') {
-          // Lower-case so that `isAddress()` can handle it
-          value.newValue = value.newValue.toLowerCase();
+        } else if (value.type === 'address') {
+          // Normalize address
+          value.oldValue = getAddress(value.oldValue);
+          value.newValue = getAddress(value.newValue.toLowerCase());
         }
-        return {
-          ...acc,
-          [paramKey]: value,
-        };
+
+        // if something has changed, add it
+        if (value.newValue !== value.oldValue) {
+          return {
+            ...acc,
+            [paramKey]: value,
+          };
+        }
       }
+
       return acc;
     }, {});
   }
@@ -166,22 +195,27 @@ const CreateGovernanceSlate: StatelessPage<any> = () => {
 
       const paramKeys = Object.keys(parameterChanges);
 
-      const proposalMetadatas: IGovernanceProposalMetadata[] = paramKeys.map((param: string) => {
+      const proposalMetadatas: IGovernanceProposalMetadata[] = paramKeys.map((param: string): IGovernanceProposalMetadata => {
+        const { oldValue, newValue, type, key } = parameterChanges[param];
+
         return {
-          id: Object.keys(parameterChanges).length,
           firstName: values.firstName,
           lastName: values.lastName,
           summary: values.summary,
           organization: values.organization,
           parameterChanges: {
-            ...parameterChanges[param],
+            key,
+            oldValue,
+            newValue,
+            type,
           },
         };
       });
+
       const proposalMultihashes: Buffer[] = await Promise.all(
         proposalMetadatas.map(async (metadata: IGovernanceProposalMetadata) => {
           try {
-            const multihash: string = await ipfsAddObject(metadata);
+            const multihash: string = await saveToIpfs(metadata);
             // we need a buffer of the multihash for the transaction
             return Buffer.from(multihash);
           } catch (error) {
@@ -211,21 +245,20 @@ const CreateGovernanceSlate: StatelessPage<any> = () => {
       setPendingText('Adding slate to IPFS...');
       const resource = contracts.parameterStore.address;
 
-      // TODO: change the metadata format to include resource (but maybe include a human-readable resourceType)
-      const slateMetadata: IGovernanceSlateMetadataV1 = {
+      const slateMetadata: IGovernanceSlateMetadataV2 = {
         firstName: values.firstName,
         lastName: values.lastName,
-        summary: values.summary,
+        description: values.summary,
         organization: values.organization,
-        requestIDs,
-        resource: contracts.parameterStore.address,
+        proposalMultihashes: proposalMultihashes.map(md => md.toString()),
+        proposals: proposalMetadatas,
       };
 
       console.log('slateMetadata:', slateMetadata);
 
       errorMessage = 'error saving slate metadata.';
       console.log('saving slate metadata...');
-      const slateMetadataHash: string = await ipfsAddObject(slateMetadata);
+      const slateMetadataHash: string = await saveToIpfs(slateMetadata);
 
       setPendingText('Creating governance slate (check MetaMask)...');
       // Submit the slate info to the contract
@@ -311,20 +344,7 @@ const CreateGovernanceSlate: StatelessPage<any> = () => {
                   lastName: 'Last',
                   organization: 'Ethereum',
                   summary: 'fdsfdsfasdfadsfsad',
-                  parameters: {
-                    slateStakeAmount: {
-                      oldValue: '',
-                      newValue: '',
-                      type: 'uint256',
-                      key: 'slateStakeAmount',
-                    },
-                    gatekeeperAddress: {
-                      oldValue: '',
-                      newValue: '',
-                      type: 'address',
-                      key: 'gatekeeperAddress',
-                    },
-                  },
+                  parameters: initialParameters,
                   recommendation: 'governance',
                   stake: 'no',
                 }
@@ -334,20 +354,7 @@ const CreateGovernanceSlate: StatelessPage<any> = () => {
                   lastName: '',
                   organization: '',
                   summary: '',
-                  parameters: {
-                    slateStakeAmount: {
-                      oldValue: '',
-                      newValue: '',
-                      type: 'uint256',
-                      key: 'slateStakeAmount',
-                    },
-                    gatekeeperAddress: {
-                      oldValue: '',
-                      newValue: '',
-                      type: 'address',
-                      key: 'gatekeeperAddress',
-                    },
-                  },
+                  parameters: initialParameters,
                   recommendation: 'governance',
                   stake: 'no',
                 }
@@ -364,11 +371,20 @@ const CreateGovernanceSlate: StatelessPage<any> = () => {
               const noChanges: IParameterChangesObject = {};
               await handleSubmitSlate(values, noChanges);
             } else {
-              const changes: IParameterChangesObject = filterParameterChanges(values.parameters);
-              if (Object.keys(changes).length === 0) {
-                setFieldError('parametersForm', 'You must enter some parameters to change');
-              } else {
-                await handleSubmitSlate(values, changes);
+              try {
+                const changes: IParameterChangesObject = filterParameterChanges(values.parameters);
+                if (Object.keys(changes).length === 0) {
+                  setFieldError('parametersForm', 'You must enter some parameter values different from the old ones');
+                } else {
+                  await handleSubmitSlate(values, changes);
+                }
+              } catch (error) {
+                // some issue with filtering the changes - should never get here
+                const errorType = handleGenericError(error, toast);
+                if (errorType) {
+                  toast.error(`Problem submitting slate: ${error.message}`);
+                }
+                console.error(error);
               }
             }
 
@@ -443,8 +459,7 @@ const CreateGovernanceSlate: StatelessPage<any> = () => {
                       <SectionLabel>{'PARAMETERS'}</SectionLabel>
                       <ParametersForm
                         onChange={setFieldValue}
-                        newSlateStakeAmount={values.parameters.slateStakeAmount.newValue}
-                        newGatekeeperAddress={values.parameters.gatekeeperAddress.newValue}
+                        parameters={values.parameters}
                         errors={errors}
                       />
                     </>

--- a/client/pages/slates/create/governance.tsx
+++ b/client/pages/slates/create/governance.tsx
@@ -34,6 +34,7 @@ import {
   IGovernanceProposalMetadata,
   IGovernanceProposalInfo,
   IParameterChangesObject,
+  ISlateMetadata,
 } from '../../../interfaces';
 import ParametersForm from '../../../components/ParametersForm';
 import {
@@ -53,6 +54,15 @@ enum PageStatus {
   Initialized,
   SubmissionOpen,
   SubmissionClosed,
+}
+
+interface IGovernanceSlateMetadataV1 {
+  firstName: string;
+  lastName?: string;
+  organization?: string;
+  summary: string;
+  requestIDs: string[];
+  resource: string;
 }
 
 const CreateGovernanceSlate: StatelessPage<any> = () => {
@@ -199,8 +209,10 @@ const CreateGovernanceSlate: StatelessPage<any> = () => {
       const requestIDs = await getRequests;
 
       setPendingText('Adding slate to IPFS...');
+      const resource = contracts.parameterStore.address;
+
       // TODO: change the metadata format to include resource (but maybe include a human-readable resourceType)
-      const slateMetadata: any = {
+      const slateMetadata: IGovernanceSlateMetadataV1 = {
         firstName: values.firstName,
         lastName: values.lastName,
         summary: values.summary,
@@ -220,7 +232,7 @@ const CreateGovernanceSlate: StatelessPage<any> = () => {
       errorMessage = 'error submitting slate.';
       const slate: any = await sendRecommendGovernanceSlateTx(
         contracts.gatekeeper,
-        slateMetadata.resource,
+        resource,
         requestIDs,
         slateMetadataHash
       );

--- a/client/pages/slates/create/grant.tsx
+++ b/client/pages/slates/create/grant.tsx
@@ -42,13 +42,12 @@ import {
   sendCreateManyProposalsTransaction,
   sendStakeTokensTransaction,
 } from '../../../utils/transaction';
-import { ipfsAddObject } from '../../../utils/ipfs';
 import {
   convertedToBaseUnits,
   formatPanvalaUnits,
   baseToConvertedUnits,
 } from '../../../utils/format';
-import { postSlate } from '../../../utils/api';
+import { postSlate, saveToIpfs } from '../../../utils/api';
 import { PROPOSAL } from '../../../utils/constants';
 import Flex from '../../../components/system/Flex';
 import BackButton from '../../../components/BackButton';
@@ -308,7 +307,7 @@ const CreateGrantSlate: StatelessPage<IProps> = ({ query }) => {
       const proposalMultihashes: Buffer[] = await Promise.all(
         selectedProposals.map(async (metadata: IGrantProposalMetadata) => {
           try {
-            const multihash: string = await ipfsAddObject(metadata);
+            const multihash: string = await saveToIpfs(metadata);
             // we need a buffer of the multihash for the transaction
             return Buffer.from(multihash);
           } catch (error) {
@@ -369,7 +368,7 @@ const CreateGrantSlate: StatelessPage<IProps> = ({ query }) => {
 
       console.log('saving slate metadata...');
       errorMessagePrefix = 'error saving slate metadata';
-      const slateMetadataHash: string = await ipfsAddObject(slateMetadata);
+      const slateMetadataHash: string = await saveToIpfs(slateMetadata);
 
       // Submit the slate info to the contract
       errorMessagePrefix = 'error submitting slate';

--- a/client/pages/slates/slate.tsx
+++ b/client/pages/slates/slate.tsx
@@ -12,7 +12,11 @@ import { PROPOSAL } from '../../utils/constants';
 import SlateHeader from '../../components/SlateHeader';
 import SlateSidebar from '../../components/SlateSidebar';
 import Flex, { BreakableFlex } from '../../components/system/Flex';
-import { splitAddressHumanReadable, formatParameter } from '../../utils/format';
+import {
+  splitAddressHumanReadable,
+  formatParameter,
+  parameterDisplayName,
+} from '../../utils/format';
 
 const Incumbent = styled.div`
   color: ${colors.blue};
@@ -78,7 +82,7 @@ const GrantSlateDetail = ({ slate }) => {
 };
 
 interface IGovProps {
-  slate: ISlate,
+  slate: ISlate;
 }
 
 interface IChange {
@@ -88,13 +92,13 @@ interface IChange {
   key: any;
 }
 
-const GovernanceSlateDetail = ({ slate }: IGovProps ) => {
+const GovernanceSlateDetail = ({ slate }: IGovProps) => {
   const hasProposals = slate.proposals && slate.proposals.length > 0;
 
   // We expect a key `parameterChanges on each proposal
   // HACK, coerce to governance proposal until we work out an ISlate that encompasses all types of
   // proposals
-  const proposals = (slate.proposals as unknown);
+  const proposals = slate.proposals as unknown;
   const changes: IChange[] = (proposals as IGovernanceProposal[]).map(
     (p: IGovernanceProposal) => p.parameterChanges
   );
@@ -128,7 +132,7 @@ const GovernanceSlateDetail = ({ slate }: IGovProps ) => {
               key={proposal.key}
             >
               <Flex width="50%" fontSize={1}>
-                {proposal.key}
+                {parameterDisplayName(proposal.key)}
               </Flex>
               <BreakableFlex width="50%" fontSize={1}>
                 {formatParameter(proposal.oldValue, proposal.type)}

--- a/client/pages/slates/slate.tsx
+++ b/client/pages/slates/slate.tsx
@@ -7,7 +7,7 @@ import { MainContext, IMainContext } from '../../components/MainProvider';
 import RouterLink from '../../components/RouterLink';
 import RouteTitle from '../../components/RouteTitle';
 import SectionLabel from '../../components/SectionLabel';
-import { StatelessPage, ISlate, IProposal, IGovernanceProposal, IParameterChangesObject } from '../../interfaces';
+import { StatelessPage, ISlate, IProposal, IGovernanceProposal } from '../../interfaces';
 import { PROPOSAL } from '../../utils/constants';
 import SlateHeader from '../../components/SlateHeader';
 import SlateSidebar from '../../components/SlateSidebar';
@@ -77,11 +77,27 @@ const GrantSlateDetail = ({ slate }) => {
   );
 };
 
-const GovernanceSlateDetail = ({ slate }) => {
+interface IGovProps {
+  slate: ISlate,
+}
+
+interface IChange {
+  oldValue: any;
+  newValue: any;
+  type: any;
+  key: any;
+}
+
+const GovernanceSlateDetail = ({ slate }: IGovProps ) => {
   const hasProposals = slate.proposals && slate.proposals.length > 0;
 
   // We expect a key `parameterChanges on each proposal
-  const changes: IParameterChangesObject[] = slate.proposals.map(p => p.parameterChanges);
+  // HACK, coerce to governance proposal until we work out an ISlate that encompasses all types of
+  // proposals
+  const proposals = (slate.proposals as unknown);
+  const changes: IChange[] = (proposals as IGovernanceProposal[]).map(
+    (p: IGovernanceProposal) => p.parameterChanges
+  );
 
   return (
     <>
@@ -100,7 +116,7 @@ const GovernanceSlateDetail = ({ slate }) => {
             </Flex>
           </Flex>
 
-          {changes.map((proposal: IParameterChangesObject) => (
+          {changes.map((proposal: IChange) => (
             <Flex
               p={3}
               justifyBetween

--- a/client/pages/slates/slate.tsx
+++ b/client/pages/slates/slate.tsx
@@ -7,11 +7,12 @@ import { MainContext, IMainContext } from '../../components/MainProvider';
 import RouterLink from '../../components/RouterLink';
 import RouteTitle from '../../components/RouteTitle';
 import SectionLabel from '../../components/SectionLabel';
-import { StatelessPage, ISlate, IProposal } from '../../interfaces';
+import { StatelessPage, ISlate, IProposal, IGovernanceProposal } from '../../interfaces';
 import { PROPOSAL } from '../../utils/constants';
 import SlateHeader from '../../components/SlateHeader';
 import SlateSidebar from '../../components/SlateSidebar';
-import { splitAddressHumanReadable } from '../../utils/format';
+import Flex, { BreakableFlex } from '../../components/system/Flex';
+import { splitAddressHumanReadable, formatParameter } from '../../utils/format';
 
 const Incumbent = styled.div`
   color: ${colors.blue};
@@ -44,6 +45,86 @@ interface IProps {
     id: string;
   };
 }
+
+const GrantSlateDetail = ({ slate }) => {
+  const hasProposals = slate.proposals && slate.proposals.length > 0;
+  return (
+    <>
+      <SectionLabel>{'GRANTS'}</SectionLabel>
+      {hasProposals ? (
+        <SlateProposals>
+          {slate.proposals.map((proposal: IProposal) => (
+            <RouterLink
+              href={`/proposals/proposal?id=${proposal.id}`}
+              as={`/proposals/${proposal.id}`}
+              key={proposal.id}
+            >
+              <Card
+                title={proposal.title}
+                subtitle={proposal.tokensRequested + ' Tokens Requested'}
+                description={proposal.summary}
+                category={'GRANT PROPOSAL'}
+                type={PROPOSAL}
+                width={['100%', '100%', '100%', '50%']}
+              />
+            </RouterLink>
+          ))}
+        </SlateProposals>
+      ) : (
+        <div>No proposals included.</div>
+      )}
+    </>
+  );
+};
+
+const GovernanceSlateDetail = ({ slate }) => {
+  const hasProposals = slate.proposals && slate.proposals.length > 0;
+  return (
+    <>
+      <SectionLabel>{'PARAMETER CHANGES'}</SectionLabel>
+      {hasProposals ? (
+        <Flex column mt={4}>
+          <Flex p={3} justifyBetween alignCenter width="100%" fontWeight="bold" bg="greys.light">
+            <Flex justifyStart width="50%">
+              Parameter Name
+            </Flex>
+            <Flex justifyStart width="50%">
+              Current Value
+            </Flex>
+            <Flex justifyStart width="50%">
+              New Value
+            </Flex>
+          </Flex>
+
+          {slate.proposals.map((proposal: IGovernanceProposal) => (
+            <Flex
+              p={3}
+              justifyBetween
+              alignCenter
+              width="100%"
+              bg="white"
+              border={1}
+              borderColor="greys.light"
+              key={proposal.key}
+            >
+              <Flex width="50%" fontSize={1}>
+                {proposal.key}
+              </Flex>
+              <BreakableFlex width="50%" fontSize={1}>
+                {formatParameter(proposal.oldValue, proposal.type)}
+              </BreakableFlex>
+              <BreakableFlex width="50%" fontSize={1}>
+                {formatParameter(proposal.newValue, proposal.type)}
+              </BreakableFlex>
+            </Flex>
+          ))}
+        </Flex>
+      ) : (
+        <div>No proposals included.</div>
+      )}
+    </>
+  );
+};
 
 const Slate: StatelessPage<IProps> = ({ query: { id } }) => {
   const { slates, currentBallot }: IMainContext = React.useContext(MainContext);
@@ -85,29 +166,11 @@ const Slate: StatelessPage<IProps> = ({ query: { id } }) => {
             {slate.description}
           </Box>
 
-          {slate.proposals && slate.proposals.length > 0 ? (
-            <>
-              <SectionLabel>{'GRANTS'}</SectionLabel>
-              <SlateProposals>
-                {slate.proposals.map((proposal: IProposal) => (
-                  <RouterLink
-                    href={`/proposals/proposal?id=${proposal.id}`}
-                    as={`/proposals/${proposal.id}`}
-                    key={proposal.id}
-                  >
-                    <Card
-                      title={proposal.title}
-                      subtitle={proposal.tokensRequested + ' Tokens Requested'}
-                      description={proposal.summary}
-                      category={`${slate.category} PROPOSAL`}
-                      type={PROPOSAL}
-                      width={['100%', '100%', '100%', '50%']}
-                    />
-                  </RouterLink>
-                ))}
-              </SlateProposals>
-            </>
-          ) : null}
+          {slate.category === 'GRANT' ? (
+            <GrantSlateDetail slate={slate} />
+          ) : (
+            <GovernanceSlateDetail slate={slate} />
+          )}
         </MainColumn>
       </DetailContainer>
     </SlateWrapper>

--- a/client/pages/slates/slate.tsx
+++ b/client/pages/slates/slate.tsx
@@ -7,7 +7,7 @@ import { MainContext, IMainContext } from '../../components/MainProvider';
 import RouterLink from '../../components/RouterLink';
 import RouteTitle from '../../components/RouteTitle';
 import SectionLabel from '../../components/SectionLabel';
-import { StatelessPage, ISlate, IProposal, IGovernanceProposal } from '../../interfaces';
+import { StatelessPage, ISlate, IProposal, IGovernanceProposal, IParameterChangesObject } from '../../interfaces';
 import { PROPOSAL } from '../../utils/constants';
 import SlateHeader from '../../components/SlateHeader';
 import SlateSidebar from '../../components/SlateSidebar';
@@ -79,6 +79,10 @@ const GrantSlateDetail = ({ slate }) => {
 
 const GovernanceSlateDetail = ({ slate }) => {
   const hasProposals = slate.proposals && slate.proposals.length > 0;
+
+  // We expect a key `parameterChanges on each proposal
+  const changes: IParameterChangesObject[] = slate.proposals.map(p => p.parameterChanges);
+
   return (
     <>
       <SectionLabel>{'PARAMETER CHANGES'}</SectionLabel>
@@ -96,7 +100,7 @@ const GovernanceSlateDetail = ({ slate }) => {
             </Flex>
           </Flex>
 
-          {slate.proposals.map((proposal: IGovernanceProposal) => (
+          {changes.map((proposal: IParameterChangesObject) => (
             <Flex
               p={3}
               justifyBetween

--- a/client/utils/api.ts
+++ b/client/utils/api.ts
@@ -154,3 +154,28 @@ export async function getNotificationsByAddress(address: string): Promise<any | 
     throw error;
   }
 }
+
+export async function saveToIpfs(data: object) {
+  try {
+    const response = await axios({
+      method: 'post',
+      url: `${apiHost}/api/ipfs`,
+      data,
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...corsHeaders,
+      },
+    });
+
+    if (response.status === 200) {
+      return response.data;
+    } else {
+      console.error(response.data);
+
+      throw new Error(response.data);
+    }
+  } catch (error) {
+    throw handleApiError(error);
+  }
+}

--- a/client/utils/format.ts
+++ b/client/utils/format.ts
@@ -49,3 +49,15 @@ export function formatPanvalaUnits(base: BigNumberish): string {
 }
 
 export const BN = (small: BigNumberish) => utils.bigNumberify(small);
+
+export type ParameterFormat = 'uint256' | 'address';
+
+export const formatParameter = (value: any, type: ParameterFormat): string => {
+  if (type === 'uint256') {
+    return formatPanvalaUnits(value);
+  } else if (type === 'address') {
+    return utils.getAddress(value);
+  } else {
+    return value;
+  }
+}

--- a/client/utils/format.ts
+++ b/client/utils/format.ts
@@ -60,6 +60,15 @@ export const formatParameter = (value: any, type: ParameterFormat): string => {
   } else {
     return value;
   }
-}
+};
 
 export const { getAddress } = utils;
+
+const parameterDisplayNames = {
+  slateStakeAmount: 'Slate Stake Amount',
+  gatekeeperAddress: 'Gatekeeper Address',
+};
+
+export function parameterDisplayName(key: string): string {
+  return parameterDisplayNames[key] || key;
+}

--- a/client/utils/format.ts
+++ b/client/utils/format.ts
@@ -61,3 +61,5 @@ export const formatParameter = (value: any, type: ParameterFormat): string => {
     return value;
   }
 }
+
+export const { getAddress } = utils;

--- a/client/utils/format.ts
+++ b/client/utils/format.ts
@@ -67,6 +67,7 @@ export const { getAddress } = utils;
 const parameterDisplayNames = {
   slateStakeAmount: 'Slate Stake Amount',
   gatekeeperAddress: 'Gatekeeper Address',
+  stakeDonationAddress: 'Losing Stake Donation Address',
 };
 
 export function parameterDisplayName(key: string): string {

--- a/client/utils/ipfs.ts
+++ b/client/utils/ipfs.ts
@@ -19,6 +19,7 @@ export async function ipfsGetData(multihash: string) {
       return ipfs.cat(multihash, (err: any, result: string) => {
         if (err) {
           reject(new Error(`IPFS get: ${err.message}`));
+          return;
         }
 
         try {
@@ -43,6 +44,7 @@ export async function ipfsAddObject(obj: any): Promise<string> {
       if (err) {
         const msg = `IPFS add: ${err.message}`;
         reject(new Error(msg));
+        return;
       }
 
       try {


### PR DESCRIPTION
Display details of governance slates in the individual slate view. Update the governance slate metadata format to more closely match the grant slate metadata. Properly handle form initial values to include the `oldValue` and save it in the metadata.

Additional improvements:
- Use the caching IPFS API call when saving slate and proposal metadata
- Pass parameters object to `ParametersForm` and parse it to generate the form instead of hard-coding the parameters