### PR TITLE
rm extraneous ipfs code

### DIFF
--- a/api/controllers/slate.js
+++ b/api/controllers/slate.js
@@ -1,6 +1,5 @@
 const { validationResult } = require('express-validator');
 const { utils } = require('ethers');
-const ipfs = require('../utils/ipfs');
 const { getAllSlates } = require('../utils/slates');
 const { IpfsMetadata, Slate } = require('../models');
 
@@ -67,23 +66,6 @@ module.exports = {
           }
         })
       );
-    }
-
-    if (process.env.NODE_ENV !== 'test') {
-      // this could be problematic
-      // maybe we should move all `ipfs.add` logic to the api (for adding slate metadata, that would be here)
-      const slateMetadata = await ipfs.get(multihash, { json: true });
-
-      // write slate metadata to db, but don't duplicate
-      await IpfsMetadata.findOrCreate({
-        where: {
-          multihash,
-        },
-        defaults: {
-          multihash,
-          data: slateMetadata,
-        },
-      });
     }
 
     Slate.create({


### PR DESCRIPTION
the ipfs POST endpoint `/api/ipfs` is being used in the client to save the slate to ipfs and the db (api does this asynchronously), but during postSlate, the api calls `ipfs.get()` directly in order to save it to the db. this pr removes that chunk of code since it's being taken care of during the previous step