### PR TITLE
Add .sequelizerc

### DIFF
--- a/api/.sequelizerc
+++ b/api/.sequelizerc
@@ -1,0 +1,8 @@
+const path = require('path');
+
+module.exports = {
+  'config': path.resolve('src', 'config', 'config.js'),
+  'models-path': path.resolve('src', 'models'),
+  'seeders-path': path.resolve('src', 'seeders'),
+  'migrations-path': path.resolve('src', 'migrations')
+}


### PR DESCRIPTION
We moved the Sequelize-related files from their default locations, so add a `.sequelizerc` so the cli can still find them.