### PR TITLE
Do not immediately delete database migration job

### DIFF
--- a/charts/panvala-api/templates/db-migrate-job.yaml
+++ b/charts/panvala-api/templates/db-migrate-job.yaml
@@ -9,7 +9,8 @@ metadata:
     helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   activeDeadlineSeconds: 60
   backoffLimit: 1


### PR DESCRIPTION
Keep the database migration job around until the next time it runs, for debugging purposes.