### PR TITLE
Add API endpoint to submit poll responses

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -18,6 +18,8 @@
     "migrate": "sequelize db:migrate",
     "migrate:undo": "sequelize db:migrate:undo",
     "create-migration": "sequelize migration:generate --name",
+    "seed": "sequelize db:seed:all",
+    "poll:create": "ts-node scripts/createPoll.ts",
     "sync-events": "ts-node scripts/sync-contract-events.ts",
     "test": "jest"
   },
@@ -47,7 +49,7 @@
     "@types/express": "^4.17.1",
     "@types/jest": "^24.0.18",
     "@types/morgan": "^1.7.37",
-    "@types/node": "^12.7.11",
+    "@types/node": "^12.12.4",
     "@types/sequelize": "^4.28.6",
     "@types/supertest": "^2.0.8",
     "@types/umzug": "^2.2.2",

--- a/api/package.json
+++ b/api/package.json
@@ -38,7 +38,7 @@
     "panvala-utils": "file:../packages/panvala-utils",
     "pg": "^7.8.0",
     "pg-hstore": "^2.3.2",
-    "sequelize": "5.18.1",
+    "sequelize": "5.21.2",
     "sequelize-cli": "^5.4.0"
   },
   "devDependencies": {
@@ -50,6 +50,7 @@
     "@types/node": "^12.7.11",
     "@types/sequelize": "^4.28.6",
     "@types/supertest": "^2.0.8",
+    "@types/umzug": "^2.2.2",
     "gulp": "^4.0.2",
     "gulp-typescript": "^5.0.1",
     "husky": "^2.4.0",

--- a/api/scripts/createPoll.ts
+++ b/api/scripts/createPoll.ts
@@ -1,0 +1,31 @@
+import { getCategories, createPoll } from '../src/utils/polls';
+import { sequelize } from '../src/models';
+
+sequelize.options.logging = false;
+
+// TODO: allow the user to create polls with just some of the categories
+// TODO: allow the user to add new categories
+
+async function run() {
+  // if there are no categories, prompt the user to create them
+  const categories = await getCategories();
+  if (categories.length === 0) {
+    console.log('No funding categories found');
+    console.log('');
+    console.log("> Did you remember to run 'yarn seed'?");
+    process.exit(0);
+  }
+
+  // create the poll
+  console.log('creating poll');
+  const name = 'A poll';
+  const categoryNames = categories.map(c => c.displayName);
+
+  const poll = await createPoll(name, categoryNames);
+
+  console.log(`created poll ${name} with id ${poll.id}`);
+  // console.log(poll.get({ plain: true }));
+  process.exit(0);
+}
+
+run();

--- a/api/scripts/nukedb.ts
+++ b/api/scripts/nukedb.ts
@@ -1,5 +1,12 @@
 import * as readline from 'readline';
-const { SubmittedBallot, Slate, IpfsMetadata, Request } = require('../src/models');
+const {
+  SubmittedBallot,
+  Slate,
+  IpfsMetadata,
+  Request,
+  CategoryPoll,
+  FundingCategory,
+} = require('../src/models');
 
 const rl = readline.createInterface({
   input: process.stdin,
@@ -11,6 +18,8 @@ const tables = {
   SubmittedBallot: SubmittedBallot,
   IpfsMetadata: IpfsMetadata,
   Request: Request,
+  CategoryPoll: CategoryPoll,
+  FundingCategory: FundingCategory,
 };
 
 (async function nukedb() {

--- a/api/src/controllers/poll.ts
+++ b/api/src/controllers/poll.ts
@@ -1,0 +1,32 @@
+import { validatePollResponseStructure } from '../utils/validation';
+import { addPollResponse } from '../utils/polls';
+
+// Return the newly created response
+export async function saveResponse(req, res) {
+  //
+  const { response } = req.body;
+  const valid = validatePollResponseStructure(req.body);
+
+  if (!valid) {
+    const msg = 'Invalid poll response request data';
+    const errors = validatePollResponseStructure.errors;
+
+    // console.error(errors);
+    return res.status(400).json({
+      msg,
+      errors,
+    });
+  }
+
+  // TODO: validate signature
+
+  return addPollResponse(response)
+    .then(savedResponse => {
+      return res.json(savedResponse);
+    })
+    .catch(error => {
+      return res.status(400).json({
+        msg: error.message,
+      });
+    });
+}

--- a/api/src/controllers/poll.ts
+++ b/api/src/controllers/poll.ts
@@ -6,10 +6,21 @@ import {
   IPollData,
   IDBPollResponse,
   ensureChecksumAddress,
+  getPollByID,
 } from '../utils/polls';
 
 // Return the newly created response
 export async function saveResponse(req, res) {
+  const data: IPollData = req.body;
+  const { pollID: rawPollID } = req.params;
+
+  // If the given pollID does not represent a valid poll, return 404
+  const { isValidPollID: isValid, pollID } = await validatePollID(rawPollID);
+  if (!isValid) {
+    return res.status(404).send();
+  }
+
+  // validate structure
   const valid = validatePollResponseStructure(req.body);
 
   if (!valid) {
@@ -23,9 +34,7 @@ export async function saveResponse(req, res) {
     });
   }
 
-  const data: IPollData = req.body;
   const { response, signature } = data;
-  const { pollID } = req.params;
 
   const responseToSave: IDBPollResponse = {
     ...response,
@@ -53,16 +62,17 @@ export async function saveResponse(req, res) {
 }
 
 export async function getUserStatus(req, res) {
-  const { pollID } = req.params;
-  let { account } = req.params;
+  const { pollID: rawPollID } = req.params;
+  let { account: rawAccount } = req.params;
 
-  try {
-    account = ensureChecksumAddress(account);
-  } catch (error) {
-    console.error(error);
-    return res.status(400).json({
-      msg: `Invalid Ethereum address '${account}'`,
-    });
+  const { isValidPollID: isValid, pollID } = await validatePollID(rawPollID);
+  if (!isValid) {
+    return res.status(404).send();
+  }
+
+  const { isValidAddress, account } = await validateAddress(rawAccount);
+  if (!isValidAddress) {
+    return res.status(404).send();
   }
 
   return hasAccountRespondedToPoll(pollID, account)
@@ -78,4 +88,35 @@ export async function getUserStatus(req, res) {
         msg: error.message,
       });
     });
+}
+
+// Helpers
+
+async function validatePollID(
+  rawPollID: string
+): Promise<{ isValidPollID: boolean; pollID: number }> {
+  const pollID: number = parseInt(rawPollID);
+  const result = { isValidPollID: true, pollID };
+
+  if (Number.isNaN(pollID)) {
+    return { isValidPollID: false, pollID: null };
+  }
+
+  const poll = await getPollByID(pollID);
+  if (poll == null) {
+    return { isValidPollID: false, pollID: null };
+  }
+
+  return result;
+}
+
+function validateAddress(account: string): { isValidAddress: boolean; account: string } {
+  try {
+    account = ensureChecksumAddress(account);
+  } catch (error) {
+    console.error(error);
+    return { isValidAddress: false, account };
+  }
+
+  return { isValidAddress: true, account };
 }

--- a/api/src/controllers/poll.ts
+++ b/api/src/controllers/poll.ts
@@ -1,5 +1,5 @@
 import { validatePollResponseStructure } from '../utils/validation';
-import { addPollResponse } from '../utils/polls';
+import { addPollResponse, verifyPollSignature } from '../utils/polls';
 
 // Return the newly created response
 export async function saveResponse(req, res) {
@@ -18,7 +18,13 @@ export async function saveResponse(req, res) {
     });
   }
 
-  // TODO: validate signature
+  // Validate signature
+  const validSignature = await verifyPollSignature(req.body);
+  if (!validSignature) {
+    return res.status(403).json({
+      msg: 'Signature does not match account',
+    });
+  }
 
   return addPollResponse(response)
     .then(savedResponse => {

--- a/api/src/controllers/poll.ts
+++ b/api/src/controllers/poll.ts
@@ -55,6 +55,13 @@ export async function saveResponse(req, res) {
     })
     .catch(error => {
       console.error(error);
+
+      if (error.name === 'SequelizeUniqueConstraintError') {
+        return res.status(403).json({
+          msg: error.message,
+        });
+      }
+
       return res.status(400).json({
         msg: error.message,
       });

--- a/api/src/controllers/poll.ts
+++ b/api/src/controllers/poll.ts
@@ -1,5 +1,5 @@
 import { validatePollResponseStructure } from '../utils/validation';
-import { addPollResponse, verifyPollSignature } from '../utils/polls';
+import { addPollResponse, verifyPollSignature, hasAccountRespondedToPoll } from '../utils/polls';
 
 // Return the newly created response
 export async function saveResponse(req, res) {
@@ -35,4 +35,14 @@ export async function saveResponse(req, res) {
         msg: error.message,
       });
     });
+}
+
+export async function getUserStatus(req, res) {
+  const { pollID, account } = req.params;
+  const responded = await hasAccountRespondedToPoll(pollID, account);
+
+  const status = {
+    responded,
+  };
+  return res.json(status);
 }

--- a/api/src/migrations/20191028222004-create-funding-category.js
+++ b/api/src/migrations/20191028222004-create-funding-category.js
@@ -1,0 +1,30 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('FundingCategories', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      code: {
+        type: Sequelize.STRING,
+      },
+      displayName: {
+        type: Sequelize.STRING,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('FundingCategories');
+  },
+};

--- a/api/src/migrations/20191028223515-create-category-poll.js
+++ b/api/src/migrations/20191028223515-create-category-poll.js
@@ -1,0 +1,27 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('CategoryPolls', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      name: {
+        type: Sequelize.TEXT,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('CategoryPolls');
+  },
+};

--- a/api/src/migrations/20191029181821-create-category-poll-option.js
+++ b/api/src/migrations/20191029181821-create-category-poll-option.js
@@ -1,0 +1,42 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('CategoryPollOptions', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      pollID: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'CategoryPolls',
+          key: 'id',
+        },
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      },
+      categoryID: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'FundingCategories',
+          key: 'id',
+        },
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('CategoryPollOptions');
+  },
+};

--- a/api/src/migrations/20191029211120-create-category-poll-response.js
+++ b/api/src/migrations/20191029211120-create-category-poll-response.js
@@ -1,0 +1,38 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('CategoryPollResponses', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      pollID: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'CategoryPolls',
+          key: 'id',
+        },
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      },
+      account: {
+        allowNull: false,
+        type: Sequelize.STRING,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('CategoryPollResponses');
+  },
+};

--- a/api/src/migrations/20191029211159-create-category-poll-allocation.js
+++ b/api/src/migrations/20191029211159-create-category-poll-allocation.js
@@ -1,0 +1,52 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('CategoryPollAllocations', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      pollResponseID: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'CategoryPollResponses',
+          key: 'id',
+        },
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      },
+      categoryID: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'FundingCategories',
+          key: 'id',
+        },
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      },
+      points: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        validate: {
+          min: 0,
+          max: 100,
+        },
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('CategoryPollAllocations');
+  },
+};

--- a/api/src/migrations/20191105214615-unique-poll-response-constraint.js
+++ b/api/src/migrations/20191105214615-unique-poll-response-constraint.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addConstraint('CategoryPollResponses', ['pollID', 'account'], {
+      type: 'unique',
+      name: 'singlePollResponsePerAccount',
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeConstraint('CategoryPollResponses', 'singlePollResponsePerAccount');
+  },
+};

--- a/api/src/models/categoryPoll.js
+++ b/api/src/models/categoryPoll.js
@@ -1,0 +1,27 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const CategoryPoll = sequelize.define(
+    'CategoryPoll',
+    {
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+    },
+    {}
+  );
+  CategoryPoll.associate = function(models) {
+    // --> poll.getOptions()
+    CategoryPoll.hasMany(models.CategoryPollOption, {
+      as: 'options',
+      foreignKey: 'pollID',
+    });
+
+    // --> poll.getResponses()
+    CategoryPoll.hasMany(models.CategoryPollResponse, {
+      as: 'responses',
+      foreignKey: 'pollID',
+    });
+  };
+  return CategoryPoll;
+};

--- a/api/src/models/categoryPollAllocation.js
+++ b/api/src/models/categoryPollAllocation.js
@@ -1,0 +1,21 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const CategoryPollAllocation = sequelize.define(
+    'CategoryPollAllocation',
+    {
+      pollResponseID: DataTypes.INTEGER,
+      categoryID: DataTypes.INTEGER,
+      points: DataTypes.INTEGER,
+    },
+    {}
+  );
+  CategoryPollAllocation.associate = function(models) {
+    // --> pollAllocation.getPollResponse()
+    CategoryPollAllocation.belongsTo(models.CategoryPollResponse, {
+      as: 'pollResponse',
+      foreignKey: 'pollResponseID',
+      // TODO: unique pollResponse, category
+    });
+  };
+  return CategoryPollAllocation;
+};

--- a/api/src/models/categoryPollOption.js
+++ b/api/src/models/categoryPollOption.js
@@ -1,0 +1,19 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const CategoryPollOption = sequelize.define(
+    'CategoryPollOption',
+    {
+      pollID: DataTypes.INTEGER,
+      categoryID: DataTypes.INTEGER,
+    },
+    {}
+  );
+  CategoryPollOption.associate = function(models) {
+    // --> pollOption.getPoll()
+    CategoryPollOption.belongsTo(models.CategoryPoll, {
+      as: 'poll',
+      foreignKey: 'pollID',
+    });
+  };
+  return CategoryPollOption;
+};

--- a/api/src/models/categoryPollResponse.js
+++ b/api/src/models/categoryPollResponse.js
@@ -6,9 +6,13 @@ module.exports = (sequelize, DataTypes) => {
   const CategoryPollResponse = sequelize.define(
     'CategoryPollResponse',
     {
-      pollID: DataTypes.INTEGER,
+      pollID: {
+        type: DataTypes.INTEGER,
+        unique: 'singlePollResponsePerAccount',
+      },
       account: {
         type: DataTypes.STRING,
+        unique: 'singlePollResponsePerAccount',
         validate: {
           notEmpty: true,
         },

--- a/api/src/models/categoryPollResponse.js
+++ b/api/src/models/categoryPollResponse.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const _ = require('lodash');
+
+module.exports = (sequelize, DataTypes) => {
+  const CategoryPollResponse = sequelize.define(
+    'CategoryPollResponse',
+    {
+      pollID: DataTypes.INTEGER,
+      account: {
+        type: DataTypes.STRING,
+        validate: {
+          notEmpty: true,
+        },
+      },
+    },
+    {
+      validate: {
+        async validCategories() {
+          const pollOptions = await this.getPoll().then(poll => poll.getOptions());
+
+          if (this.allocations.length !== pollOptions.length) {
+            throw new Error('Response must match number of poll options');
+          }
+          // check categories
+          const categories = pollOptions.map(option => option.categoryID);
+          const categoriesToSave = this.allocations.map(allocation => allocation.categoryID);
+
+          if (!_.isEqual(categories.sort(), categoriesToSave.sort())) {
+            throw new Error('Response categories must match poll options');
+          }
+        },
+        pointsAddUp() {
+          const total = this.allocations.reduce((acc, current) => {
+            return acc + current.points;
+          }, 0);
+
+          if (total !== 100) {
+            throw new Error('Points must add up to 100');
+          }
+        },
+      },
+    }
+  );
+
+  CategoryPollResponse.associate = function(models) {
+    // --> response.getAllocations()
+    CategoryPollResponse.hasMany(models.CategoryPollAllocation, {
+      as: 'allocations',
+      foreignKey: 'pollResponseID',
+    });
+
+    // --> response.getPoll()
+    CategoryPollResponse.belongsTo(models.CategoryPoll, {
+      as: 'poll',
+      foreignKey: 'pollID',
+    });
+  };
+  return CategoryPollResponse;
+};

--- a/api/src/models/fundingCategory.js
+++ b/api/src/models/fundingCategory.js
@@ -1,0 +1,15 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const FundingCategory = sequelize.define(
+    'FundingCategory',
+    {
+      code: DataTypes.STRING,
+      displayName: DataTypes.STRING,
+    },
+    {}
+  );
+  FundingCategory.associate = function(models) {
+    // associations can be defined here
+  };
+  return FundingCategory;
+};

--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -16,6 +16,7 @@ import * as parameter from './controllers/parameter';
 import * as ipfs from './controllers/ipfs';
 import * as website from './controllers/website';
 import * as token from './controllers/token';
+import * as poll from './controllers/poll';
 
 // Routes
 export const setupRoutes = app => {
@@ -81,4 +82,7 @@ export const setupRoutes = app => {
 
   // Token
   app.get('/api/token/circulating-supply', token.circulatingSupply);
+
+  // Polls
+  app.post('/api/polls/:pollID', poll.saveResponse);
 };

--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -85,4 +85,5 @@ export const setupRoutes = app => {
 
   // Polls
   app.post('/api/polls/:pollID', poll.saveResponse);
+  app.get('/api/polls/:pollID/status/:account', poll.getUserStatus);
 };

--- a/api/src/seeders/20191028222230-initial-poll-categories.js
+++ b/api/src/seeders/20191028222230-initial-poll-categories.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.bulkInsert(
+      'FundingCategories',
+      [
+        { id: 1, displayName: 'Ethereum 2.0', createdAt: new Date(), updatedAt: new Date() },
+        { id: 2, displayName: 'Layer 2 Scaling', createdAt: new Date(), updatedAt: new Date() },
+        { id: 3, displayName: 'Security', createdAt: new Date(), updatedAt: new Date() },
+        {
+          id: 4,
+          displayName: 'Developer Tools and Growth',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        { id: 5, displayName: 'Dapps and Usability', createdAt: new Date(), updatedAt: new Date() },
+        { id: 6, displayName: 'Panvala', createdAt: new Date(), updatedAt: new Date() },
+      ],
+      {}
+    );
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.bulkDelete('FundingCategories', null, {});
+  },
+};

--- a/api/src/test/polls.test.ts
+++ b/api/src/test/polls.test.ts
@@ -14,6 +14,7 @@ import {
   responseCount,
   ICategoryAllocation,
   IPollResponse,
+  IDBPollResponse,
   createSignedResponse,
   hasAccountRespondedToPoll,
 } from '../utils/polls';
@@ -90,11 +91,10 @@ describe('API endpoints', () => {
 
       response = {
         account: wallet.address,
-        pollID,
         allocations,
       };
 
-      data = await createSignedResponse(wallet, response);
+      data = await createSignedResponse(wallet, { ...response, pollID });
     });
 
     test('should create a poll response', async () => {
@@ -199,7 +199,7 @@ describe('API endpoints', () => {
     let pollID: number;
     let route: string;
     let data: IPollData;
-    let response: IPollResponse;
+    let response: IDBPollResponse;
     let wallet;
 
     beforeEach(async () => {
@@ -333,7 +333,7 @@ describe('poll utilities', () => {
   describe('active poll', () => {
     let pollID: number;
     let poll;
-    let response: IPollResponse;
+    let response: IDBPollResponse;
 
     beforeEach(async () => {
       poll = await createPoll('Poll', categoryNames);

--- a/api/src/test/polls.test.ts
+++ b/api/src/test/polls.test.ts
@@ -245,6 +245,21 @@ describe('API endpoints', () => {
       const status = result.body;
       expect(status.responded).toBe(true);
     });
+
+    test('it should return 400 if the account is invalid', async () => {
+      await addPollResponse(response);
+
+      const badAccount = '0xabc';
+      route = `${baseRoute}/${pollID}/status/${badAccount}`;
+
+      // check status
+      const result = await request(app)
+        .get(route)
+        .send(data);
+
+      expect(result.status).toBe(400);
+      expect(result.body.msg).toEqual(expect.stringContaining('Invalid Ethereum address'));
+    });
   });
 });
 

--- a/api/src/test/polls.test.ts
+++ b/api/src/test/polls.test.ts
@@ -140,6 +140,17 @@ describe('API endpoints', () => {
       expect(result.status).toBe(404);
     });
 
+    test('it should return 403 if the account has already responded to the poll', async () => {
+      await addPollResponse({ ...data.response, pollID });
+
+      const result = await request(app)
+        .post(route)
+        .send(data);
+
+      console.log(result.body);
+      expect(result.status).toBe(403);
+    });
+
     // invalid shape
     describe('invalid shape', () => {
       const requiredFields = ['signature', 'response'];
@@ -486,7 +497,12 @@ describe('poll utilities', () => {
     });
 
     test.todo('it should not allow multiple allocations to the same option');
-    test.todo('it should not allow multiple responses from the same account');
+
+    test('it should not allow multiple responses from the same account', async () => {
+      await addPollResponse(response);
+
+      await expect(addPollResponse(response)).rejects.toThrow();
+    });
 
     describe('hasAccountRespondedToPoll', () => {
       test('it should return true if the account has responded', async () => {

--- a/api/src/test/utils.ts
+++ b/api/src/test/utils.ts
@@ -53,4 +53,6 @@ function initProposals() {
   );
 }
 
+export const someAddress = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
 export { initProposals };

--- a/api/src/test/utils.ts
+++ b/api/src/test/utils.ts
@@ -1,3 +1,5 @@
+import { Wallet } from 'ethers';
+
 import * as models from '../models';
 const { Proposal } = models;
 
@@ -54,5 +56,10 @@ function initProposals() {
 }
 
 export const someAddress = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
+export function getWallet() {
+  return Wallet.fromMnemonic(mnemonic);
+}
 
 export { initProposals };

--- a/api/src/utils/index.ts
+++ b/api/src/utils/index.ts
@@ -1,1 +1,18 @@
 export { voting, contractABIs, timing } from 'panvala-utils';
+
+export function hasDuplicates(array: any[]): boolean {
+  const counter = {};
+
+  for (const element of array) {
+    const stored = counter[element];
+    if (stored == null) {
+      counter[element] = 1;
+    } else {
+      if (stored === 1) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}

--- a/api/src/utils/polls.ts
+++ b/api/src/utils/polls.ts
@@ -140,13 +140,25 @@ export interface ICategoryAllocation {
  * @returns newly created response
  */
 export async function addPollResponse(response: IPollResponse) {
-  return CategoryPollResponse.create(response, {
+  const sanitizedResponse: IPollResponse = response;
+  sanitizedResponse.account = ensureChecksumAddress(response.account);
+
+  return CategoryPollResponse.create(sanitizedResponse, {
     include: [{ model: CategoryPollAllocation, as: 'allocations' }],
   });
 }
 
 export async function responseCount(pollID: number): Promise<number> {
   return CategoryPollResponse.count({ where: { pollID } });
+}
+
+export async function hasAccountRespondedToPoll(pollID: number, account: string) {
+  return CategoryPollResponse.findOne({
+    where: { pollID, account: ensureChecksumAddress(account) },
+  }).then(response => {
+    // console.log(response);
+    return response != null;
+  });
 }
 
 // ===== Calculations

--- a/api/src/utils/polls.ts
+++ b/api/src/utils/polls.ts
@@ -1,0 +1,151 @@
+import { Sequelize } from '../models';
+import { hasDuplicates } from '.';
+const {
+  FundingCategory,
+  CategoryPoll,
+  CategoryPollOption,
+  CategoryPollResponse,
+  CategoryPollAllocation,
+} = require('../models');
+const { in: opIn } = Sequelize.Op;
+
+// ===== Categories
+
+export async function getCategories() {
+  return FundingCategory.findAll();
+}
+
+export async function getCategoryByName(name: string) {
+  return FundingCategory.findOne({ where: { displayName: name } });
+}
+
+// Throw if the category already exists
+export async function createCategory(name: string) {
+  const data = {
+    displayName: name,
+  };
+
+  return FundingCategory.create(data);
+}
+
+// ===== Polls
+
+/**
+ * Return the poll with the options included
+ * @param pollID
+ */
+export async function getPollByID(pollID: number) {
+  return CategoryPoll.findOne({
+    where: { id: pollID },
+    include: [{ model: CategoryPollOption, as: 'options' }],
+  });
+}
+
+export async function createEmptyPoll(name: string) {
+  return CategoryPoll.create(
+    { name },
+    {
+      include: [{ model: CategoryPollOption, as: 'options' }],
+    }
+  );
+}
+
+export async function createPoll(name: string, categoryNames: string[]) {
+  // check that the categories are unique
+  if (hasDuplicates(categoryNames)) {
+    throw new Error('Duplicate categories');
+  }
+
+  // get categories matching the given strings
+  const where = {
+    displayName: {
+      [opIn]: categoryNames,
+    },
+  };
+  const categories = await FundingCategory.findAll({ where });
+  if (categories.length !== categoryNames.length) {
+    throw new Error('Invalid categories included');
+  }
+
+  // create poll with the given categories, return the poll with its options
+  return CategoryPoll.create({
+    name,
+  }).then(poll => {
+    const options = categories.map(cat => {
+      return { pollID: poll.id, categoryID: cat.id };
+    });
+    return CategoryPollOption.bulkCreate(options).then(() =>
+      poll.reload({
+        include: [
+          {
+            model: CategoryPollOption,
+            as: 'options',
+          },
+        ],
+      })
+    );
+  });
+}
+
+/**
+ * Add an option to an existing poll
+ *
+ * @param pollID
+ * @param name
+ * @returns poll with options included
+ */
+export async function addPollOption(pollID: number, name: string) {
+  // throws if poll does not exist
+  const poll = await CategoryPoll.findOne({ where: { id: pollID } });
+  // console.log('FOUND POLL', poll.get({plain: true}));
+
+  // get or create a category, then create an option
+  return FundingCategory.findOrCreate({ where: { displayName: name } }).then(result => {
+    const [category] = result;
+    // console.log('CATEGORY', category.get({plain:true}));
+
+    // associate it
+    return CategoryPollOption.create({
+      pollID: poll.id,
+      categoryID: category.id,
+    }).then(() => getPollByID(pollID));
+  });
+}
+
+// ===== Responses
+
+export interface IPollData {
+  signature: string;
+  response: IPollResponse;
+}
+
+export interface IPollResponse {
+  account: string;
+  pollID: number;
+  allocations: ICategoryAllocation[];
+}
+
+export interface ICategoryAllocation {
+  categoryID: number;
+  points: number;
+}
+
+/**
+ * Add a response to an existing poll
+ * allocations must match the poll options
+ * @param response
+ * @returns newly created response
+ */
+export async function addPollResponse(response: IPollResponse) {
+  return CategoryPollResponse.create(response, {
+    include: [{ model: CategoryPollAllocation, as: 'allocations' }],
+  });
+}
+
+export async function responseCount(pollID: number): Promise<number> {
+  return CategoryPollResponse.count({ where: { pollID } });
+}
+
+// - calculations
+// sign poll response
+// validate poll response

--- a/api/src/utils/polls.ts
+++ b/api/src/utils/polls.ts
@@ -165,7 +165,7 @@ export async function hasAccountRespondedToPoll(pollID: number, account: string)
 }
 
 // ===== Calculations
-function ensureChecksumAddress(address: string): string {
+export function ensureChecksumAddress(address: string): string {
   return getAddress(address.toLowerCase());
 }
 

--- a/api/src/utils/schemas.ts
+++ b/api/src/utils/schemas.ts
@@ -12,5 +12,6 @@ function loadSchema(filepath) {
 const ballotSchema = loadSchema('schemas/ballot.json');
 const proposalSchema = loadSchema('schemas/proposal.json');
 const slateSchema = loadSchema('schemas/slate.json');
+export const pollResponseSchema = loadSchema('schemas/categoryPollResponse.json');
 
 export { ballotSchema, proposalSchema, slateSchema };

--- a/api/src/utils/schemas/categoryPollResponse.json
+++ b/api/src/utils/schemas/categoryPollResponse.json
@@ -42,10 +42,6 @@
     "signature": {
       "type": "string",
       "signature": true
-    },
-    "commitHash": {
-      "type": "string",
-      "pattern": "^0x[a-fA-F0-9]+$"
     }
   },
   "required": ["response", "signature"]

--- a/api/src/utils/schemas/categoryPollResponse.json
+++ b/api/src/utils/schemas/categoryPollResponse.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://panvala.com/schemas/categoryPollResponse.json",
+  "title": "Category poll response",
+  "description": "A ballot POSTed to poll endpoint",
+  "type": "object",
+  "definitions": {
+    "choice": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "response": {
+      "type": "object",
+      "properties": {
+        "pollID": {
+          "type": "number",
+          "$comment": "Non-zero integer",
+          "pattern": "^[1-9]+"
+        },
+        "account": {
+          "type": "string",
+          "address": true
+        },
+        "allocations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "categoryID": {
+                "type": "number"
+              },
+              "points": {
+                "type": "number"
+              }
+            },
+            "required": ["categoryID", "points"]
+          }
+        }
+      },
+      "required": ["account", "pollID", "allocations"]
+    },
+    "signature": {
+      "type": "string",
+      "signature": true
+    },
+    "commitHash": {
+      "type": "string",
+      "pattern": "^0x[a-fA-F0-9]+$"
+    }
+  },
+  "required": ["response", "signature"]
+}

--- a/api/src/utils/schemas/categoryPollResponse.json
+++ b/api/src/utils/schemas/categoryPollResponse.json
@@ -23,10 +23,13 @@
             "type": "object",
             "properties": {
               "categoryID": {
-                "type": "number"
+                "type": "integer",
+                "minimum": 1
               },
               "points": {
-                "type": "number"
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 100
               }
             },
             "required": ["categoryID", "points"]

--- a/api/src/utils/schemas/categoryPollResponse.json
+++ b/api/src/utils/schemas/categoryPollResponse.json
@@ -13,11 +13,6 @@
     "response": {
       "type": "object",
       "properties": {
-        "pollID": {
-          "type": "number",
-          "$comment": "Non-zero integer",
-          "pattern": "^[1-9]+"
-        },
         "account": {
           "type": "string",
           "address": true
@@ -38,7 +33,8 @@
           }
         }
       },
-      "required": ["account", "pollID", "allocations"]
+      "additionalProperties": false,
+      "required": ["account", "allocations"]
     },
     "signature": {
       "type": "string",

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -464,10 +464,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.30.tgz#4c2b4f0015f214f8158a347350481322b3b29b2f"
   integrity sha512-nsqTN6zUcm9xtdJiM9OvOJ5EF0kOI8f1Zuug27O/rgtxCRJHGqncSWfCMZUP852dCKPsDsYXGvBhxfRjDBkF5Q==
 
-"@types/node@^12.7.11":
-  version "12.7.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.11.tgz#be879b52031cfb5d295b047f5462d8ef1a716446"
-  integrity sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==
+"@types/node@^12.12.4":
+  version "12.12.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.4.tgz#8ed27dba0a83b020fca035f003ffe21f70207a9c"
+  integrity sha512-tJUH7//zNZ/539DH4cgZS3NsmW0b9ShDeRBzoCEMCEAlHn5WHUghOfHdycvpo4RCxxEPmQ3WfjDogh+DCCvuSg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -347,6 +347,13 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/bson@*":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/bson/-/bson-4.0.0.tgz#9073772679d749116eb1dfca56f8eaac6d59cc7a"
+  integrity sha512-pq/rqJwJWkbS10crsG5bgnrisL8pML79KlMKQMoQwLUjlPAkrUHMvHJ3oGwE7WHR61Lv/nadMwXVAD2b+fpD8Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/connect@*":
   version "3.4.32"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.32.tgz#aa0e9616b9435ccad02bc52b5b454ffc2c70ba28"
@@ -432,6 +439,14 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
   integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
 
+"@types/mongodb@*":
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.3.7.tgz#f11fbad6ea48135634bce7e70080031cb35c5c84"
+  integrity sha512-X/yDgFAgn3ypXN/CcckHe3nzxaliGtvrJ52kW2k9MAHDfYpc83wvvqHECfmx88pfrrquxFgRWqCTXprqABPfbw==
+  dependencies:
+    "@types/bson" "*"
+    "@types/node" "*"
+
 "@types/morgan@^1.7.37":
   version "1.7.37"
   resolved "https://registry.yarnpkg.com/@types/morgan/-/morgan-1.7.37.tgz#ebdd0b0f0276073f85283bf4f03c7c54284874df"
@@ -464,7 +479,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/sequelize@^4.28.6":
+"@types/sequelize@*", "@types/sequelize@^4.28.6":
   version "4.28.6"
   resolved "https://registry.yarnpkg.com/@types/sequelize/-/sequelize-4.28.6.tgz#01d2f1d3781cc34448cd63c2fd97bdb0612b15de"
   integrity sha512-mtNHjfbS1DwQoYaBGuWW8aw6IUTkrq2XbjjAqcAqPLasxTbu8mXkz3n2VCNiytK18Z/kGtvh6U0VlK4BWXDbwA==
@@ -501,6 +516,14 @@
   integrity sha512-wcax7/ip4XSSJRLbNzEIUVy2xjcBIZZAuSd2vtltQfRK7kxhx5WMHbLHkYdxN3wuQCrwpYrg86/9byDjPXoGMA==
   dependencies:
     "@types/superagent" "*"
+
+"@types/umzug@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@types/umzug/-/umzug-2.2.2.tgz#0a17d4bd5c8b2416024c8d7cb25a55a79a53b075"
+  integrity sha512-1QN9IdwPsSftLniv2hguPSJQMnSQE8Eu+RzOOy5KlrLS75NLtAP7dGI11JkS0o2XoY1QdF0KTEGoGJ7zAawQuQ==
+  dependencies:
+    "@types/mongodb" "*"
+    "@types/sequelize" "*"
 
 "@types/validator@*":
   version "10.11.3"
@@ -6179,7 +6202,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-retry-as-promised@^3.1.0:
+retry-as-promised@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/retry-as-promised/-/retry-as-promised-3.2.0.tgz#769f63d536bec4783549db0777cb56dadd9d8543"
   integrity sha512-CybGs60B7oYU/qSQ6kuaFmRd9sTZ6oXSc0toqePvV74Ac6/IFZSI1ReFQmtCN+uvW1Mtqdwpvt/LGOiCBAY2Mg==
@@ -6335,7 +6358,7 @@ semver@^5.0.3, semver@^5.1.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
-semver@^6.0.0, semver@^6.1.1, semver@^6.2.0:
+semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -6378,26 +6401,26 @@ sequelize-pool@^2.3.0:
   resolved "https://registry.yarnpkg.com/sequelize-pool/-/sequelize-pool-2.3.0.tgz#64f1fe8744228172c474f530604b6133be64993d"
   integrity sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA==
 
-sequelize@5.18.1:
-  version "5.18.1"
-  resolved "https://registry.yarnpkg.com/sequelize/-/sequelize-5.18.1.tgz#31d5246dcdf01d0ac317454c28fb598359d5b60a"
-  integrity sha512-jngo7pqilyOycMv6ZEwHLVn2wuHi/xkSQZfwK4jhjG8ta1HWYJK3XyQDFdhVEOH1GEq9pnqaf+7Kwqm+eqXD9Q==
+sequelize@5.21.2:
+  version "5.21.2"
+  resolved "https://registry.yarnpkg.com/sequelize/-/sequelize-5.21.2.tgz#0daeee9bef37d49490b72a2c6891d53044f65a18"
+  integrity sha512-MEqJ9NwQi4oy/ylLb2WkfPmhki/BOXC/gJfc8uWUUTETcpLwD1y/5bI1kqVh+qWcECHNsE9G4lmhj5hFbsxqvA==
   dependencies:
     bluebird "^3.5.0"
     cls-bluebird "^2.1.0"
     debug "^4.1.1"
     dottie "^2.0.0"
     inflection "1.12.0"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     moment "^2.24.0"
     moment-timezone "^0.5.21"
-    retry-as-promised "^3.1.0"
-    semver "^6.1.1"
+    retry-as-promised "^3.2.0"
+    semver "^6.3.0"
     sequelize-pool "^2.3.0"
     toposort-class "^1.0.1"
-    uuid "^3.2.1"
+    uuid "^3.3.3"
     validator "^10.11.0"
-    wkx "^0.4.6"
+    wkx "^0.4.8"
 
 serve-static@1.13.2:
   version "1.13.2"
@@ -7359,7 +7382,7 @@ uuid@2.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.1.tgz#c2a30dedb3e535d72ccf82e343941a50ba8533ac"
   integrity sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=
 
-uuid@^3.2.1, uuid@^3.3.2:
+uuid@^3.3.2, uuid@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
@@ -7541,7 +7564,7 @@ widest-line@^2.0.0:
   dependencies:
     string-width "^2.1.1"
 
-wkx@^0.4.6:
+wkx@^0.4.8:
   version "0.4.8"
   resolved "https://registry.yarnpkg.com/wkx/-/wkx-0.4.8.tgz#a092cf088d112683fdc7182fd31493b2c5820003"
   integrity sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==


### PR DESCRIPTION
Submit poll responses to `/api/polls/:pollID`. The poll with the given ID must already exist in the database. Get status for an account at `/api/polls/:pollID/status/:account`.