### PR TITLE
add network check for mainnet during connectWallet

### DIFF
--- a/gatsby-site/src/pages/poll.js
+++ b/gatsby-site/src/pages/poll.js
@@ -178,6 +178,12 @@ const Poll = () => {
     if (typeof window !== 'undefined' && typeof window.ethereum !== 'undefined') {
       if (typeof provider === 'undefined') {
         const p = new providers.Web3Provider(window.ethereum);
+        const network = await p.getNetwork();
+        if (network.chainId !== 1) {
+          alert('Please connect to the Main Network to continue.');
+          return;
+        }
+
         setProvider(p);
         const acct = (await p.listAccounts())[0];
         return acct;
@@ -587,7 +593,7 @@ const Poll = () => {
                       <div key={identifier} className="cf pa3 bb bw-2 b--black-10">
                         <div className="fl w-80 pa2 pr4">
                           <div className="f4 b">{title}</div>
-                          <p dangerouslySetInnerHTML={{__html: description}}></p>
+                          <p dangerouslySetInnerHTML={{ __html: description }}></p>
                         </div>
                         <div className="fl w-20 pa2 f5 tr">
                           <div className="b ttu f6 o-50">previous batch</div>

--- a/gatsby-site/src/pages/poll.js
+++ b/gatsby-site/src/pages/poll.js
@@ -180,7 +180,7 @@ const Poll = () => {
         const p = new providers.Web3Provider(window.ethereum);
         const network = await p.getNetwork();
         if (network.chainId !== 1) {
-          alert('Please connect to the Main Network to continue.');
+          alert('Please connect to the Main Ethereum Network to continue.');
           return;
         }
 


### PR DESCRIPTION
this check is pretty restrictive to mainnet, but i think it's a good workaround because it forces mainnet (where it only really matters at the moment). unfortunately if the user hasn't connected their wallet by the time they submit the form, it clears the field values and forces the user to enter them again. but i think this is still the simplest fix for the network mismatch issue.