### PR TITLE
handle errors for reverted contract calls

### DIFF
--- a/api/src/utils/eth.ts
+++ b/api/src/utils/eth.ts
@@ -44,7 +44,7 @@ async function getContracts() {
 
   const uniswapExchangeAddress =
     network.chainId === 4
-      ? '0xA062C59F42a45f228BEBB6e7234Ed1ea14398dE7' // rinkeby
+      ? '0x25EAd1E8e3a9C38321488BC5417c999E622e36ea' // rinkeby
       : network.chainId === 1
       ? '0xF53bBFBff01c50F2D42D542b09637DcA97935fF7' // mainnet
       : '';

--- a/api/src/utils/events.ts
+++ b/api/src/utils/events.ts
@@ -70,7 +70,7 @@ async function getAllEvents(fromBlock) {
 
     return events;
   } catch (error) {
-    console.log('error:', error);
+    console.log('eth-events error:', error);
     return [];
   }
 }

--- a/api/src/utils/slates.ts
+++ b/api/src/utils/slates.ts
@@ -33,12 +33,10 @@ async function getAllSlates() {
 
   let grantsIncumbent, governanceIncumbent: string | undefined;
   if (gatekeeper.functions.hasOwnProperty('incumbent')) {
-    try {
-      grantsIncumbent = await gatekeeper.functions.incumbent(tokenCapacitorAddress);
-      governanceIncumbent = await gatekeeper.functions.incumbent(parameterStore.address);
-    } catch (error) {
-      // ignore errors. incumbents left undefined
-    }
+    [grantsIncumbent, governanceIncumbent] = await Promise.all([
+      gatekeeper.functions.incumbent(tokenCapacitorAddress),
+      gatekeeper.functions.incumbent(parameterStore.address),
+    ]);
   }
 
   // 0..slateCount

--- a/api/src/utils/slates.ts
+++ b/api/src/utils/slates.ts
@@ -30,10 +30,15 @@ async function getAllSlates() {
   console.log(`fetching ${slateCount} slates`);
   const currentEpoch = await gatekeeper.functions.currentEpochNumber();
   console.log('currentEpoch:', currentEpoch);
-  let grantsIncumbent, governanceIncumbent;
+
+  let grantsIncumbent, governanceIncumbent: string | undefined;
   if (gatekeeper.functions.hasOwnProperty('incumbent')) {
-    grantsIncumbent = await gatekeeper.functions.incumbent(tokenCapacitorAddress);
-    governanceIncumbent = await gatekeeper.functions.incumbent(parameterStore.address);
+    try {
+      grantsIncumbent = await gatekeeper.functions.incumbent(tokenCapacitorAddress);
+      governanceIncumbent = await gatekeeper.functions.incumbent(parameterStore.address);
+    } catch (error) {
+      // ignore errors. incumbents left undefined
+    }
   }
 
   // 0..slateCount
@@ -268,6 +273,7 @@ export async function getWinningSlate(slates?: any[], epochNumber?: BigNumberish
     const winningSlateID = await gatekeeper.getWinningSlate(lastEpochNumber, tokenCapacitorAddress);
     return slates.find(slate => slate.id === winningSlateID.toNumber());
   } catch (error) {
+    console.log('Error getting winning slate:', error);
     throw error;
   }
 }

--- a/gatsby-site/src/components/BudgetProvider.js
+++ b/gatsby-site/src/components/BudgetProvider.js
@@ -15,17 +15,18 @@ const BudgetProvider = ({ children }) => {
     async function getData() {
       const budgets = await getBudgets();
 
-      const formatted = {
-        epochPAN: `${prettify(budgets.epochBudgetPAN)} PAN`,
-        epochUSD: `($${prettify(budgets.epochBudgetUSD)} USD)`,
-        annualPAN: `${prettify(budgets.annualBudgetPAN)} PAN`,
-        annualUSD: `($${prettify(budgets.annualBudgetUSD)} USD)`,
-        epochNumber: budgets.epochNumber,
-      };
+      if (!budgets.errors) {
+        const formatted = {
+          epochPAN: `${prettify(budgets.epochBudgetPAN)} PAN`,
+          epochUSD: `($${prettify(budgets.epochBudgetUSD)} USD)`,
+          annualPAN: `${prettify(budgets.annualBudgetPAN)} PAN`,
+          annualUSD: `($${prettify(budgets.annualBudgetUSD)} USD)`,
+          epochNumber: budgets.epochNumber,
+        };
+        console.log('formatted:', formatted);
 
-      setBudgets(formatted);
-
-      console.log('formatted:', formatted);
+        setBudgets(formatted);
+      }
     }
 
     getData();

--- a/gatsby-site/src/utils/format.js
+++ b/gatsby-site/src/utils/format.js
@@ -66,5 +66,9 @@ export function formatDates(epochDates) {
 }
 
 export function prettify(ugly) {
-  return utils.commify(sliceDecimals(ugly));
+  // TEMPORARY until typescript refactor
+  if (typeof ugly === 'string') {
+    return utils.commify(sliceDecimals(ugly));
+  }
+  return ugly;
 }


### PR DESCRIPTION
`getWinningSlate`, `incumbent`, and `projectedUnlockedBalance`
revert if the state conditions have not been met. previously we were
not handling api calls which then run these contract calls. this commit
wraps the calls in try/catch and either returns a useful error response
or ignores the exception because the value can be left `undefined`.