### PR TITLE
Fix race condition in approval-donation flow

### DIFF
--- a/gatsby-site/src/components/Donation.tsx
+++ b/gatsby-site/src/components/Donation.tsx
@@ -461,7 +461,12 @@ class Donation extends React.Component<Props> {
         message: 'Approving tokens...',
       });
       // Approve token capacitor
-      await this.token.functions.approve(this.tokenCapacitor.address, constants.MaxUint256);
+      const tx = await this.token.functions.approve(this.tokenCapacitor.address, constants.MaxUint256);
+      this.setState({
+        message: 'Waiting for transaction confirmation...',
+      });
+      await this.provider.waitForTransaction(tx.hash);
+
       // Call donate again
       return this.donatePan(multihash);
     }

--- a/gatsby-site/src/components/Sponsorship.tsx
+++ b/gatsby-site/src/components/Sponsorship.tsx
@@ -402,62 +402,66 @@ class Sponsorship extends React.Component {
       this.state.panPurchased
     );
 
-    if (allowed) {
+    try {
+      // approve if necessary
+      if (!allowed) {
+        this.setState({
+          message: 'Approving tokens...',
+        });
+        // Approve token capacitor
+        const approveTx = await this.token.functions.approve(
+          this.tokenCapacitor.address,
+          constants.MaxUint256
+        );
+        console.log('approval', approveTx.hash);
+      }
+
+      // donate
       this.setState({
         message: 'Donating PAN...',
       });
+
       const gasPrice = await getGasPrice();
-      try {
-        const donor = this.state.selectedAccount;
-        // Donate PAN to token capacitor
-        const donateTx = await this.tokenCapacitor.functions.donate(
-          donor,
-          this.state.panPurchased,
-          Buffer.from(multihash),
-          {
-            gasLimit: hexlify(150000), // 150K
-            gasPrice: gasPrice || hexlify(12e9), // 12 GWei
-          }
-        );
+      const donor = this.state.selectedAccount;
+      // Donate PAN to token capacitor
+      const donateTx = await this.tokenCapacitor.functions.donate(
+        donor,
+        this.state.panPurchased,
+        Buffer.from(multihash),
+        {
+          gasLimit: hexlify(150000), // 150K
+          gasPrice: gasPrice || hexlify(12e9), // 12 GWei
+        }
+      );
+      console.log('donation', donateTx.hash);
 
-        // Wait for tx to be mined
-        await this.provider.waitForTransaction(donateTx.hash);
-
-        this.setState({
-          step: 3,
-          message: this.state.tier,
-        });
-
-        // Return tx info
-        return {
-          txHash: donateTx.hash,
-          metadataHash: multihash,
-          donor,
-          sender: donor,
-          tokens: this.state.panPurchased,
-        };
-      } catch (error) {
-        console.error(`ERROR: ${error.message}`);
-        alert(`Donate transaction failed: ${error.message}`);
-        await this.setState({
-          step: null,
-          message: '',
-        });
-        return false;
-      }
-    } else {
-      this.setState({
-        message: 'Approving tokens...',
-      });
-      // Approve token capacitor
-      const tx = await this.token.functions.approve(this.tokenCapacitor.address, constants.MaxUint256);
+      // Wait for tx to be mined
       this.setState({
         message: 'Waiting for transaction confirmation...',
       });
-      await this.provider.waitForTransaction(tx.hash);
+      await this.provider.waitForTransaction(donateTx.hash);
 
-      // Call donate again
-      return this.donatePan(multihash);
+      this.setState({
+        step: 3,
+        message: this.state.tier,
+      });
+
+      // Return tx info
+      return {
+        txHash: donateTx.hash,
+        metadataHash: multihash,
+        donor,
+        sender: donor,
+        tokens: this.state.panPurchased,
+      };
+    } catch (error) {
+      console.error(`ERROR: ${error.message}`);
+      alert(`Donate transaction failed: ${error.message}`);
+      this.setState({
+        step: null,
+        message: '',
+      });
+      return false;
     }
   }
 

--- a/gatsby-site/src/components/Sponsorship.tsx
+++ b/gatsby-site/src/components/Sponsorship.tsx
@@ -450,7 +450,12 @@ class Sponsorship extends React.Component {
         message: 'Approving tokens...',
       });
       // Approve token capacitor
-      await this.token.functions.approve(this.tokenCapacitor.address, constants.MaxUint256);
+      const tx = await this.token.functions.approve(this.tokenCapacitor.address, constants.MaxUint256);
+      this.setState({
+        message: 'Waiting for transaction confirmation...',
+      });
+      await this.provider.waitForTransaction(tx.hash);
+
       // Call donate again
       return this.donatePan(multihash);
     }


### PR DESCRIPTION
Before, if the user's allowance for the token capacitor was too small, the donation flow would prompt the user to approve and send the transaction, then call `donatePan()` again. Since the approve transaction had not been approved yet, it would read the allowance as being too small and prompt the user to approve again. It would keep doing this until the approve transaction had been confirmed, causing the user to send unnecessary transactions.

This PR fixes this race condition by removing the call back into `donatePan()`. Instead, it just calls `approve()` if necessary, then immediately calls `donate()`, and waits for the donation to be confirmed before continuing.