### PR TITLE
Make donations from fundraiser pages and display current donors

### DIFF
--- a/api/src/controllers/donation.ts
+++ b/api/src/controllers/donation.ts
@@ -1,4 +1,4 @@
-import { addDonation, getPublicDonations } from '../utils/donations';
+import { addDonation, getPublicDonations, getDonationsForFundraiser } from '../utils/donations';
 import { validateDonation } from '../utils/validation';
 
 export function create(req, res) {
@@ -38,5 +38,24 @@ export function list(req, res) {
         msg: error.message,
         errors: error.errors,
       });
+    });
+}
+
+export function getByFundraiser(req, res) {
+  const { fundraiser } = req.params;
+
+  // fundraiser must be a non-empty string
+  if (fundraiser == null || typeof fundraiser !== 'string' || fundraiser.length === 0) {
+    return res.status(404);
+  }
+
+  return getDonationsForFundraiser(fundraiser)
+    .then(donations => {
+      return res.json(donations);
+    })
+    .catch(error => {
+      const msg = `Error getting donations: ${error}`;
+      console.error(msg);
+      return res.status(500).send(msg);
     });
 }

--- a/api/src/controllers/donation.ts
+++ b/api/src/controllers/donation.ts
@@ -1,4 +1,9 @@
-import { addDonation, getPublicDonations, getDonationsForFundraiser } from '../utils/donations';
+import {
+  addDonation,
+  getPublicDonations,
+  getDonationsForFundraiser,
+  getQuarterlyDonationStats,
+} from '../utils/donations';
 import { validateDonation } from '../utils/validation';
 
 export function create(req, res) {
@@ -41,11 +46,15 @@ export function list(req, res) {
     });
 }
 
+const invalidString = (value) => {
+  return value == null || typeof value !== 'string' || value.length === 0;
+}
+
 export function getByFundraiser(req, res) {
   const { fundraiser } = req.params;
 
   // fundraiser must be a non-empty string
-  if (fundraiser == null || typeof fundraiser !== 'string' || fundraiser.length === 0) {
+  if (invalidString(fundraiser)) {
     return res.status(404);
   }
 
@@ -55,6 +64,23 @@ export function getByFundraiser(req, res) {
     })
     .catch(error => {
       const msg = `Error getting donations: ${error}`;
+      console.error(msg);
+      return res.status(500).send(msg);
+    });
+}
+
+export function getStatsByFundraiser(req, res) {
+  const { fundraiser } = req.params;
+
+  // fundraiser must be a non-empty string
+  if (invalidString(fundraiser)) {
+    return res.status(404);
+  }
+
+  return getQuarterlyDonationStats(fundraiser)
+    .then(stats => res.json(stats))
+    .catch(error => {
+      const msg = `Error getting donation stats: ${error}`;
       console.error(msg);
       return res.status(500).send(msg);
     });

--- a/api/src/controllers/poll.ts
+++ b/api/src/controllers/poll.ts
@@ -5,9 +5,9 @@ import {
   hasAccountRespondedToPoll,
   IPollData,
   IDBPollResponse,
-  ensureChecksumAddress,
   getPollByID,
 } from '../utils/polls';
+import { ensureChecksumAddress } from '../utils/format';
 
 // Return the newly created response
 export async function saveResponse(req, res) {

--- a/api/src/migrations/20200107161046-add-donation-fundraiser.js
+++ b/api/src/migrations/20200107161046-add-donation-fundraiser.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('Donations', 'fundraiser', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('Donations', 'fundraiser');
+  }
+};

--- a/api/src/migrations/20200109211504-add-donation-message.js
+++ b/api/src/migrations/20200109211504-add-donation-message.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('Donations', 'message', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('Donations', 'message');
+  }
+};

--- a/api/src/models/donation.js
+++ b/api/src/models/donation.js
@@ -77,6 +77,9 @@ module.exports = (sequelize, DataTypes) => {
       // extra data
       fundraiser: {
         type: DataTypes.STRING,
+      },
+      message: {
+        type: DataTypes.STRING,
       }
     },
     {}

--- a/api/src/models/donation.js
+++ b/api/src/models/donation.js
@@ -74,6 +74,10 @@ module.exports = (sequelize, DataTypes) => {
       company: {
         type: DataTypes.STRING,
       },
+      // extra data
+      fundraiser: {
+        type: DataTypes.STRING,
+      }
     },
     {}
   );

--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -96,4 +96,7 @@ export const setupRoutes = app => {
   // Donations
   app.get('/api/donations', donation.list);
   app.post('/api/donations', donation.create);
+
+  // Fundraisers
+  app.get('/api/fundraisers/:fundraiser/donations', donation.getByFundraiser);
 };

--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -99,4 +99,5 @@ export const setupRoutes = app => {
 
   // Fundraisers
   app.get('/api/fundraisers/:fundraiser/donations', donation.getByFundraiser);
+  app.get('/api/fundraisers/:fundraiser/donations/quarter', donation.getStatsByFundraiser);
 };

--- a/api/src/test/donations.test.ts
+++ b/api/src/test/donations.test.ts
@@ -81,6 +81,7 @@ describe('API endpoints', () => {
         pledgeMonthlyUSDCents: 1500,
         pledgeTerm: 3,
         fundraiser: 'fundraiser',
+        message: 'Good cause',
       };
 
       const result = await request(app)

--- a/api/src/test/utils.ts
+++ b/api/src/test/utils.ts
@@ -1,7 +1,9 @@
 import { Wallet } from 'ethers';
 
 import * as models from '../models';
-import { parseUnits } from 'ethers/utils';
+import { parseUnits, hashMessage } from 'ethers/utils';
+import { IDonation } from '../utils/donations';
+
 const { Proposal } = models;
 
 export function initProposals() {
@@ -69,12 +71,12 @@ export function getWallet() {
 // Does case-insensitive comparison for strings, but regular strict
 // equality for other types
 function lenientValueCheck(actual: any, expected: any) {
-    const isString = typeof actual === 'string';
-    if (isString) {
-      expect(actual.toLowerCase()).toBe(expected.toLowerCase())
-    } else {
-      expect(actual).toBe(expected);
-    }
+  const isString = typeof actual === 'string';
+  if (isString) {
+    expect(actual.toLowerCase()).toBe(expected.toLowerCase());
+  } else {
+    expect(actual).toBe(expected);
+  }
 }
 
 // Check that all expected fields are there
@@ -94,3 +96,80 @@ export function expectFieldsWithTypes(actual: object, expected: object) {
 export function toBaseTokens(amount: number, decimals: number = 18): string {
   return parseUnits(amount.toString(), decimals).toString();
 }
+
+const fundraiser = 'fundraiser-1';
+const metadataHash = someCID;
+export const testFundraiserDonations: IDonation[] = [
+  {
+    txHash: hashMessage('Mary'),
+    metadataHash,
+    sender: someAddress,
+    donor: someAddress,
+    firstName: 'Mary',
+    lastName: 'Eckert',
+    tokens: '200',
+    usdValueCents: '2000',
+    fundraiser,
+  },
+  {
+    txHash: hashMessage('Nicky'),
+    metadataHash,
+    sender: someAddress,
+    donor: someAddress,
+    firstName: 'Nicky',
+    lastName: 'Stevens',
+    tokens: '100',
+    usdValueCents: '1000',
+    fundraiser,
+  },
+  {
+    txHash: hashMessage('David'),
+    metadataHash,
+    sender: someAddress,
+    donor: someAddress,
+    firstName: 'David',
+    lastName: 'West',
+    tokens: '25',
+    usdValueCents: '2500',
+    fundraiser,
+  },
+  {
+    txHash: hashMessage('nobody'),
+    metadataHash,
+    sender: someAddress,
+    donor: someAddress,
+    tokens: '25',
+    usdValueCents: '2500',
+    fundraiser,
+  },
+  {
+    txHash: hashMessage('anonymous'),
+    metadataHash,
+    sender: someAddress,
+    donor: someAddress,
+    tokens: '50',
+    usdValueCents: '5000',
+    fundraiser,
+  },
+  {
+    txHash: hashMessage('first'),
+    metadataHash,
+    sender: someAddress,
+    donor: someAddress,
+    tokens: '25',
+    usdValueCents: '2500',
+    firstName: 'John',
+    fundraiser,
+  },
+  {
+    txHash: hashMessage('David 2'),
+    metadataHash,
+    sender: someAddress,
+    donor: someAddress,
+    firstName: 'David',
+    lastName: 'West',
+    tokens: '25',
+    usdValueCents: '2500',
+    fundraiser,
+  },
+];

--- a/api/src/test/utils.ts
+++ b/api/src/test/utils.ts
@@ -57,6 +57,7 @@ export function initProposals() {
 }
 
 export const someAddress = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+export const addressB = someAddress.replace('a', 'b');
 export const someTxHash = `0x${'b'.repeat(64)}`;
 export const someCID = 'Qmbvjad1niHUjhWUrqkYUgXxgyvGbg3rFDGfZBUVx4gyJX';
 
@@ -65,16 +66,27 @@ export function getWallet() {
   return Wallet.fromMnemonic(mnemonic);
 }
 
+// Does case-insensitive comparison for strings, but regular strict
+// equality for other types
+function lenientValueCheck(actual: any, expected: any) {
+    const isString = typeof actual === 'string';
+    if (isString) {
+      expect(actual.toLowerCase()).toBe(expected.toLowerCase())
+    } else {
+      expect(actual).toBe(expected);
+    }
+}
+
 // Check that all expected fields are there
 export function expectFields(actual: object, expected: object) {
   Object.keys(expected).forEach(key => {
-    expect(actual[key]).toBe(expected[key]);
+    lenientValueCheck(actual[key], expected[key]);
   });
 }
 
 export function expectFieldsWithTypes(actual: object, expected: object) {
   Object.keys(expected).forEach(key => {
-    expect(actual[key]).toBe(expected[key]);
+    lenientValueCheck(actual[key], expected[key]);
     expect(typeof actual[key]).toBe(typeof expected[key]);
   });
 }

--- a/api/src/utils/donations.ts
+++ b/api/src/utils/donations.ts
@@ -26,7 +26,9 @@ export interface IDonation extends IPublicDonation {
   lastName?: string;
   email?: string;
   company?: string;
+  // extra fields
   fundraiser?: string;
+  message?: string;
 }
 
 export function addDonation(donation: IDonation) {

--- a/api/src/utils/donations.ts
+++ b/api/src/utils/donations.ts
@@ -1,3 +1,5 @@
+import { ensureChecksumAddress } from './format';
+
 const { Donation } = require('../models');
 
 // Base transaction info -- all required
@@ -28,7 +30,17 @@ export interface IDonation extends IPublicDonation {
 }
 
 export function addDonation(donation: IDonation) {
-  return Donation.create(donation);
+  const { sender, donor } = donation;
+
+  // Normalize donation data before saving for consistent
+  // retrieval
+  const normalized: IDonation = {
+    ...donation,
+    sender: ensureChecksumAddress(sender),
+    donor: ensureChecksumAddress(donor),
+  };
+
+  return Donation.create(normalized);
 }
 
 const publicFields = [

--- a/api/src/utils/donations.ts
+++ b/api/src/utils/donations.ts
@@ -24,26 +24,38 @@ export interface IDonation extends IPublicDonation {
   lastName?: string;
   email?: string;
   company?: string;
+  fundraiser?: string;
 }
 
 export function addDonation(donation: IDonation) {
   return Donation.create(donation);
 }
 
+const publicFields = [
+  'txHash',
+  'metadataHash',
+  'sender',
+  'donor',
+  'tokens',
+  'metadataVersion',
+  'memo',
+  'usdValueCents',
+  'ethValue',
+  'pledgeMonthlyUSDCents',
+  'pledgeTerm',
+];
+
 export function getPublicDonations(): Promise<IPublicDonation[]> {
   return Donation.findAll({
-    attributes: [
-      'txHash',
-      'metadataHash',
-      'sender',
-      'donor',
-      'tokens',
-      'metadataVersion',
-      'memo',
-      'usdValueCents',
-      'ethValue',
-      'pledgeMonthlyUSDCents',
-      'pledgeTerm',
-    ],
+    attributes: publicFields,
+  });
+}
+
+export function getDonationsForFundraiser(fundraiser: string): Promise<IPublicDonation[]> {
+  return Donation.findAll({
+    attributes: publicFields,
+    where: {
+      fundraiser,
+    },
   });
 }

--- a/api/src/utils/format.ts
+++ b/api/src/utils/format.ts
@@ -1,0 +1,9 @@
+import { getAddress } from "ethers/utils";
+
+export function ensureChecksumAddress(address: string | null): string | null {
+  if (address != null) {
+    return getAddress(address.toLowerCase());
+  }
+
+  return address;
+}

--- a/api/src/utils/polls.ts
+++ b/api/src/utils/polls.ts
@@ -1,8 +1,9 @@
 import { Wallet } from 'ethers';
-import { verifyMessage, getAddress } from 'ethers/utils';
+import { verifyMessage } from 'ethers/utils';
 
 import { Sequelize } from '../models';
 import { hasDuplicates } from '.';
+import { ensureChecksumAddress } from './format';
 const {
   FundingCategory,
   CategoryPoll,
@@ -165,9 +166,6 @@ export async function hasAccountRespondedToPoll(pollID: number, account: string)
 }
 
 // ===== Calculations
-export function ensureChecksumAddress(address: string): string {
-  return getAddress(address.toLowerCase());
-}
 
 function generateMessage(response: IDBPollResponse): string {
   // Always use checksum address in the message

--- a/api/src/utils/schemas/donation.json
+++ b/api/src/utils/schemas/donation.json
@@ -61,8 +61,7 @@
       "type": "string"
     },
     "fundraiser": {
-      "type": "string",
-      "address": true
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/api/src/utils/schemas/donation.json
+++ b/api/src/utils/schemas/donation.json
@@ -59,6 +59,10 @@
     },
     "company": {
       "type": "string"
+    },
+    "fundraiser": {
+      "type": "string",
+      "address": true
     }
   },
   "additionalProperties": false,

--- a/api/src/utils/schemas/donation.json
+++ b/api/src/utils/schemas/donation.json
@@ -62,6 +62,9 @@
     },
     "fundraiser": {
       "type": "string"
+    },
+    "message": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/gatsby-site/gatsby-node.js
+++ b/gatsby-site/gatsby-node.js
@@ -50,6 +50,7 @@ exports.createPages = async ({ graphql, actions: { createPage }, reporter }) => 
         story: node.story,
         team: node.team,
         goal: node.goal,
+        slug: node.slug,
       },
     });
   });

--- a/gatsby-site/src/components/Donation.tsx
+++ b/gatsby-site/src/components/Donation.tsx
@@ -5,7 +5,7 @@ import DonationForm from './DonationForm';
 import Box from './system/Box';
 
 import { getTier } from '../utils/donate';
-import { withDonationFlow } from './donationFlow';
+import { withDonationFlow, IDonationFlowData } from './donationFlow';
 
 interface Props {
   ethPrices: any;
@@ -23,7 +23,7 @@ const Donation = (props: Props) => {
     const { firstName, lastName, email, monthlyPledge, pledgeDuration } = values;
 
     // Data needed for the donation flow
-    const data = {
+    const data: IDonationFlowData = {
       userData: { firstName, lastName, email },
       donationMetadata: { monthlyPledge, pledgeDuration, memo: '' },
       pledgeType: 'donation',

--- a/gatsby-site/src/components/Fundraiser/DonorList.js
+++ b/gatsby-site/src/components/Fundraiser/DonorList.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import Box from '../system/Box';
+
+function calculateTotal(donations) {
+  return donations.reduce((prev, current) => {
+    return prev + parseInt(current.usdValueCents);
+  }, 0);
+}
+
+export const DonorList = props => {
+  const { donors } = props;
+
+  const knownDonors = Object.keys(donors).filter(d => d !== 'Anonymous');
+  const anonymousDonors = donors['Anonymous'] || [];
+
+  // display known donors aggregated, then individual anonymous donations
+  return (
+    <Box flex column>
+      {knownDonors.map((key, i) => {
+        const totalUsdCents = calculateTotal(donors[key]);
+        return (
+          <Box key={key}>
+            {key} - ${totalUsdCents / 100}
+          </Box>
+        );
+      })}
+
+      {anonymousDonors.map((donation, i) => {
+        return <Box key={i}>Anonymous - ${donation.usdValueCents / 100}</Box>;
+      })}
+    </Box>
+  );
+};

--- a/gatsby-site/src/components/Fundraiser/FunderBoard.js
+++ b/gatsby-site/src/components/Fundraiser/FunderBoard.js
@@ -4,9 +4,7 @@ import Box from '../system/Box';
 import DonateButton from '../DonateButton';
 
 export function FunderBoard(props) {
-  const { goal, firstName, profileLink, donations } = props;
-  // TODO: jump to donation form on click
-
+  const { goal, firstName, profileLink, donations, onDonateClick } = props;
   const { donors, totalUsdCents } = donations;
 
   const numEntries = Object.keys(donors).length;
@@ -37,7 +35,7 @@ export function FunderBoard(props) {
             <DonorList donors={donors} />
           </>
         )}
-        <DonateButton disabled={false} text="Donate" handleClick={() => null} />
+        <DonateButton disabled={false} text="Donate" handleClick={onDonateClick} />
 
         <Box>Share {firstName}'s fundraiser link</Box>
         <ProfileLink href={profileLink} />

--- a/gatsby-site/src/components/Fundraiser/FunderBoard.js
+++ b/gatsby-site/src/components/Fundraiser/FunderBoard.js
@@ -1,24 +1,43 @@
 import React from 'react';
-import { ProfileLink } from '.';
+import { ProfileLink, DonorList } from '.';
 import Box from '../system/Box';
 import DonateButton from '../DonateButton';
 
 export function FunderBoard(props) {
-  const { goal, firstName, profileLink } = props;
+  const { goal, firstName, profileLink, donations } = props;
+  // TODO: jump to donation form on click
+
+  const { donors, totalUsdCents } = donations;
+
+  const numEntries = Object.keys(donors).length;
+
+  // calculate number of people
+  const anonymousDonations = donors['Anonymous'];
+  let count = anonymousDonations == null ? numEntries : numEntries - 1 + anonymousDonations.length;
+
+  const periodStart = 'December 1';
+  const periodEnd = 'March 1';
+
+  const totalDollars = totalUsdCents / 100;
 
   return (
     <>
       <Box p={'8vw'} flex column>
-        <Box>$300 of ${goal} goal by March 1</Box>
-        <Box>Raised by 5 people since December 1</Box>
-
-        <Box flex column>
-          <Box>Funder 1</Box>
-          <Box>Funder 2</Box>
-          <Box>Funder 3</Box>
+        <Box>
+          ${totalDollars} of ${goal} goal by {periodEnd}
         </Box>
+        {numEntries === 0 ? (
+          <Box>No donations yet!</Box>
+        ) : (
+          <>
+            <Box>
+              Raised by {count} people since {periodStart}
+            </Box>
 
-        <DonateButton disabled={false} text="Test Text Donate" handleClick={() => null} />
+            <DonorList donors={donors} />
+          </>
+        )}
+        <DonateButton disabled={false} text="Donate" handleClick={() => null} />
 
         <Box>Share {firstName}'s fundraiser link</Box>
         <ProfileLink href={profileLink} />

--- a/gatsby-site/src/components/Fundraiser/FunderBoard.js
+++ b/gatsby-site/src/components/Fundraiser/FunderBoard.js
@@ -29,7 +29,7 @@ export function FunderBoard(props) {
         ) : (
           <>
             <Box>
-              Raised by {count} people since {periodStart}
+              Raised by {count} {count !== 1 ? 'people' : 'person'} since {periodStart}
             </Box>
 
             <DonorList donors={donors} />

--- a/gatsby-site/src/components/Fundraiser/FundraiserDonation.tsx
+++ b/gatsby-site/src/components/Fundraiser/FundraiserDonation.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { FundraiserForm } from './FundraiserForm';
+import { withDonationFlow, IDonationFlowData } from '../donationFlow';
+import WebsiteModal from '../WebsiteModal';
+
+const FundraiserDonation = props => {
+  async function handleDonation(values, actions) {
+    const { firstName, lastName, email, pledgeAmount } = values;
+
+    // Data needed for the donation flow
+    const data: IDonationFlowData = {
+      userData: { firstName, lastName, email, fundraiser: props.fundraiser },
+      donationMetadata: { monthlyPledge: pledgeAmount, pledgeDuration: 1, memo: '' },
+      pledgeType: 'donation',
+      // modal message: "You are now a Patron"
+      donationTier: '',
+    };
+
+    try {
+      await props.onDonate(data, actions);
+    } catch (error) {
+      alert(error.message);
+    }
+  }
+
+  return (
+    <>
+      <FundraiserForm onSubmit={handleDonation} />
+
+      <WebsiteModal
+        isOpen={true}
+        step={props.step}
+        message={props.message}
+        handleCancel={props.onCancel}
+      />
+    </>
+  );
+};
+
+const poweredFundraiserDonation = withDonationFlow(FundraiserDonation);
+export default poweredFundraiserDonation;

--- a/gatsby-site/src/components/Fundraiser/FundraiserDonation.tsx
+++ b/gatsby-site/src/components/Fundraiser/FundraiserDonation.tsx
@@ -6,12 +6,13 @@ import WebsiteModal from '../WebsiteModal';
 
 const FundraiserDonation = props => {
   async function handleDonation(values, actions) {
-    const { firstName, lastName, email, pledgeAmount } = values;
+    const { firstName, lastName, email, pledgeAmount, message } = values;
 
     // Data needed for the donation flow
     const data: IDonationFlowData = {
-      userData: { firstName, lastName, email, fundraiser: props.fundraiser },
-      donationMetadata: { monthlyPledge: pledgeAmount, pledgeDuration: 1, memo: '' },
+      userData: { firstName, lastName, email },
+      donationMetadata: { monthlyPledge: pledgeAmount, pledgeDuration: '1', memo: '' },
+      extraData: { fundraiser: props.fundraiser, message },
       pledgeType: 'donation',
       // modal message: "You are now a Patron"
       donationTier: '',

--- a/gatsby-site/src/components/Fundraiser/FundraiserForm.js
+++ b/gatsby-site/src/components/Fundraiser/FundraiserForm.js
@@ -61,8 +61,9 @@ export const FundraiserForm = ({ onSubmit }) => {
             <ErrorMessage name="pledgeAmount" component="span" />
           </div>
           <Box flex justifyContent={['space-around', 'space-between']} wrap>
-            {['10', '25', '50', '100'].map(amount => (
+            {['10', '25', '50', '100'].map((amount, i) => (
               <PledgeAmount
+                key={i}
                 text={`$${amount}/mo`}
                 handleClick={e => {
                   e.preventDefault();

--- a/gatsby-site/src/components/Fundraiser/ProfileCopy.js
+++ b/gatsby-site/src/components/Fundraiser/ProfileCopy.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Box from '../system/Box';
 
-export function ProfileCopy({ firstName, lastName, story, teamInfo, team }) {
+export function ProfileCopy({ firstName, lastName, story, team }) {
   const teamDescription = `${firstName} is fundraising for the ${team.name} team. ${team.description}`;
 
   return (

--- a/gatsby-site/src/components/Fundraiser/index.js
+++ b/gatsby-site/src/components/Fundraiser/index.js
@@ -5,3 +5,4 @@ export { FunderBoard } from './FunderBoard';
 export { FundraiserOverview } from './FundraiserOverview';
 export { ProfileCopy } from './ProfileCopy';
 export { ProfileLink } from './ProfileLink';
+export { DonorList } from './DonorList';

--- a/gatsby-site/src/components/Sponsorship.tsx
+++ b/gatsby-site/src/components/Sponsorship.tsx
@@ -4,7 +4,7 @@ import WebsiteModal from './WebsiteModal';
 import SponsorshipForm from './SponsorshipForm';
 import Box from './system/Box';
 
-import { withDonationFlow } from './donationFlow';
+import { withDonationFlow, IDonationFlowData } from './donationFlow';
 
 interface Props {
   ethPrices: any;
@@ -22,7 +22,7 @@ const Sponsorship = (props: Props) => {
     const { company, firstName, lastName, email, pledgeAmount, pledgeDuration } = values;
 
     // Data needed for the donation flow
-    const data = {
+    const data: IDonationFlowData = {
       userData: { firstName, lastName, email, company },
       donationMetadata: {
         monthlyPledge: pledgeAmount,

--- a/gatsby-site/src/components/WebsiteModal.tsx
+++ b/gatsby-site/src/components/WebsiteModal.tsx
@@ -252,7 +252,7 @@ const StepThree = ({ message, handleClose, pledgeType }) => {
       imgSrc = student;
   }
 
-  const patronMessage = pledgeType === 'sponsorship' ? 'Sponsor' : `${message} Patron`;
+  const patronMessage = pledgeType === 'sponsorship' ? 'Sponsor' : `${message} Patron`.trim();
   const tyMessage =
     pledgeType === 'sponsorship'
       ? 'Thank you for sponsoring Panvala. Panvala Sponsors play a key role in moving Ethereum forward. You can share your support on Twitter!'

--- a/gatsby-site/src/components/donationFlow.tsx
+++ b/gatsby-site/src/components/donationFlow.tsx
@@ -40,18 +40,23 @@ interface UserData {
   lastName: string;
   email: string;
   company?: string;
+}
+
+interface ExtraData {
   fundraiser?: string;
+  message?: string;
 }
 
 interface DonationMetadata {
   monthlyPledge: any;
-  pledgeDuration: number;
+  pledgeDuration: string;
   memo: string;
 }
 
 export interface IDonationFlowData {
   userData: UserData;
   donationMetadata: DonationMetadata;
+  extraData?: ExtraData;
   pledgeType: string;
   donationTier: string;
 }
@@ -402,11 +407,12 @@ export const withDonationFlow = WrappedComponent => {
     }
 
     // Execute the donation flow, throwing on error
-    async handleDonation(data, actions) {
+    async handleDonation(data: IDonationFlowData, actions) {
       // console.log('data', data);
       // TODO: validate submitted data
 
-      const { userData, donationMetadata, donationTier, pledgeType } = data;
+      const { userData, donationMetadata, donationTier, pledgeType, extraData: extra } = data;
+      const extraData = extra || {};
 
       try {
         /// 1. Connect, save metadata to IPFS, purchase PAN
@@ -458,7 +464,7 @@ export const withDonationFlow = WrappedComponent => {
           const { txHash } = txInfo;
           if (txHash) {
             // save donation data to API
-            const formattedDonation: IAPIDonation = formatDonation(txInfo, metadata, userData);
+            const formattedDonation: IAPIDonation = formatDonation(txInfo, metadata, userData, extraData);
             console.log('donation data', formattedDonation);
             await postDonation(formattedDonation);
 

--- a/gatsby-site/src/components/donationFlow.tsx
+++ b/gatsby-site/src/components/donationFlow.tsx
@@ -35,6 +35,27 @@ interface DonationState {
   error: boolean;
 }
 
+interface UserData {
+  firstName: string;
+  lastName: string;
+  email: string;
+  company?: string;
+  fundraiser?: string;
+}
+
+interface DonationMetadata {
+  monthlyPledge: any;
+  pledgeDuration: number;
+  memo: string;
+}
+
+export interface IDonationFlowData {
+  userData: UserData;
+  donationMetadata: DonationMetadata;
+  pledgeType: string;
+  donationTier: string;
+}
+
 export const withDonationFlow = WrappedComponent => {
   return class extends React.Component {
     state: DonationState;

--- a/gatsby-site/src/stories/1-fundraisers.stories.tsx
+++ b/gatsby-site/src/stories/1-fundraisers.stories.tsx
@@ -7,6 +7,7 @@ import {
   ProfileLink,
   FundraiserOverview,
   FunderBoard,
+  DonorList,
 } from '../components/Fundraiser';
 import Fundraiser from '../templates/Fundraiser';
 import { ReasonToContribute } from '../components/Fundraiser/FundraiserOverview';
@@ -22,16 +23,47 @@ const profileProps = {
   lastName: 'Last',
   story:
     'Fundraiser story Fundraiser story Fundraiser story Fundraiser story Fundraiser story Fundraiser story Fundraiser story Fundraiser story ',
-  teamInfo:
-    'Team information Team information Team information Team information Team information Team information Team information Team information',
+  goal: 1000,
+  team: {
+    name: 'Team',
+    description: 'Team information Team information Team information Team information Team information Team information Team information Team information',
+  },
+  slug: 'first-last',
+  image: { publicURL: 'https://example.com/image.png' }
 };
+
+const link = 'https://example.com/link';
+const location = { href: link };
+
+const donationStats = {
+  totalUsdCents: '45000',
+  donors: {
+    'Mary Eckert': [{ usdValueCents: '20000', timestamp: '2020-01-08T20:44:30.354Z' }],
+    'Nicky Stevens': [{ usdValueCents: '10000', timestamp: '2020-01-08T20:44:30.355Z' }],
+    'David West': [
+      { usdValueCents: '2500', timestamp: '2020-01-08T20:44:30.356Z' },
+      { usdValueCents: '2500', timestamp: '2020-01-08T20:44:30.358Z' },
+    ],
+    Anonymous: [
+      { usdValueCents: '2500', timestamp: '2020-01-08T20:44:30.356Z' },
+      { usdValueCents: '5000', timestamp: '2020-01-08T20:44:30.357Z' },
+    ],
+    John: [{ usdValueCents: '2500', timestamp: '2020-01-08T20:44:30.357Z' }],
+  },
+};
+
+const emptyDonationStats = { totalUsdCents: '0', donors: {} };
 
 export const header = () => <FundraiserHeader />;
 
 export const profileCopy = () => <ProfileCopy {...profileProps} />;
 export const profile = () => <FundraiserProfile {...profileProps} />;
-export const funderBoard = () => <FunderBoard />;
-export const profileLink = () => <ProfileLink />;
+export const donorList = () => <DonorList  donors={donationStats.donors} />;
+export const funderBoard = () => <FunderBoard profileLink={link} {...profileProps} donations={donationStats}/>;
+export const emptyFunderBoard = () => (
+  <FunderBoard profileLink={link} {...profileProps} donations={emptyDonationStats} />
+);
+export const profileLink = () => <ProfileLink href={link} />;
 
 export const reasonToContribute = () => (
   <ReasonToContribute iconSrc={flag} title="Prioritized Grants">
@@ -43,8 +75,21 @@ export const reasonToContribute = () => (
 export const overview = () => <FundraiserOverview {...profileProps} />;
 export const form = () => (
   <Layout>
-    <FundraiserForm />
+    <FundraiserForm onSubmit={() => {
+      console.log('submit');
+    }} />
   </Layout>
 );
 
-export const fullPage = () => <Fundraiser pageContext={profileProps} />;
+const pageProps = {
+  pageContext: profileProps,
+  location,
+  fetchDonations: () => {
+    console.log('story: fetching data for', profileProps.slug);
+    return donationStats;
+  }
+}
+export const fullPage = () => <Fundraiser {...pageProps} />;
+export const fullPageNoDonations = () => (
+  <Fundraiser {...pageProps} fetchDonations={() => emptyDonationStats} />
+);

--- a/gatsby-site/src/templates/Fundraiser.js
+++ b/gatsby-site/src/templates/Fundraiser.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import SEO from '../components/seo';
 import Footer from '../components/Footer';
 import Layout from '../components/Layout';
@@ -10,11 +10,46 @@ import {
   FunderBoard,
 } from '../components/Fundraiser';
 import Box from '../components/system/Box';
+import { getFundraiserDonations } from '../utils/api';
 
 const Fundraiser = props => {
   console.log('Fundraiser props:', props);
 
   const profileInfo = props.pageContext;
+  const { fetchDonations } = props;
+  const { slug: fundraiser } = profileInfo;
+
+  const [donations, setDonations] = useState({ totalUsdCents: '0', donors: {} })
+
+  useEffect(() => {
+    // fetch the donation data from the API
+    async function getData(fundraiser) {
+      if (fundraiser === '') {
+        console.log('no fundraiser set');
+        return;
+      }
+
+      console.log('fetching data for', fundraiser);
+      try {
+        const data = await getFundraiserDonations(fundraiser)
+        setDonations(data);
+      } catch (error) {
+        console.error(`Problem fetching donation data: ${error}`);
+      }
+    }
+
+    // Use the default fetching function if no function was passed in
+    if (fetchDonations == null) {
+      if (fundraiser !== '') {
+        getData(fundraiser);
+      }
+    } else {
+      // Use the passed in function (for storybook)
+      const data = fetchDonations(fundraiser)
+      console.log('fetched', data);
+      setDonations(data);
+    }
+  }, []);
 
   return (
     <Layout>
@@ -25,7 +60,7 @@ const Fundraiser = props => {
       <Box mt="-5vw" className="bottom-clip-down relative z-3" bg="white" height="1000px">
         <Box flex>
           <FundraiserProfile {...profileInfo} />
-          <FunderBoard profileLink={props.location.href} {...profileInfo} />
+          <FunderBoard profileLink={props.location.href} {...profileInfo} donations={donations} />
         </Box>
       </Box>
 

--- a/gatsby-site/src/templates/Fundraiser.js
+++ b/gatsby-site/src/templates/Fundraiser.js
@@ -1,15 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
+
 import SEO from '../components/seo';
-import Footer from '../components/Footer';
 import Layout from '../components/Layout';
 import {
   FundraiserProfile,
   FundraiserHeader,
   FundraiserOverview,
-  FundraiserForm,
   FunderBoard,
 } from '../components/Fundraiser';
 import Box from '../components/system/Box';
+import FundraiserDonation from '../components/Fundraiser/FundraiserDonation';
+
 import { getFundraiserDonations } from '../utils/api';
 
 const Fundraiser = props => {
@@ -19,7 +20,14 @@ const Fundraiser = props => {
   const { fetchDonations } = props;
   const { slug: fundraiser } = profileInfo;
 
-  const [donations, setDonations] = useState({ totalUsdCents: '0', donors: {} })
+  const [donations, setDonations] = useState({ totalUsdCents: '0', donors: {} });
+  const donateRef = useRef(null);
+
+  function onDonateClick() {
+    donateRef.current.scrollIntoView({
+      behavior: 'smooth',
+    });
+  }
 
   useEffect(() => {
     // fetch the donation data from the API
@@ -31,7 +39,7 @@ const Fundraiser = props => {
 
       console.log('fetching data for', fundraiser);
       try {
-        const data = await getFundraiserDonations(fundraiser)
+        const data = await getFundraiserDonations(fundraiser);
         setDonations(data);
       } catch (error) {
         console.error(`Problem fetching donation data: ${error}`);
@@ -45,11 +53,11 @@ const Fundraiser = props => {
       }
     } else {
       // Use the passed in function (for storybook)
-      const data = fetchDonations(fundraiser)
+      const data = fetchDonations(fundraiser);
       console.log('fetched', data);
       setDonations(data);
     }
-  }, []);
+  }, [fetchDonations, fundraiser]);
 
   return (
     <Layout>
@@ -60,15 +68,20 @@ const Fundraiser = props => {
       <Box mt="-5vw" className="bottom-clip-down relative z-3" bg="white" height="1000px">
         <Box flex>
           <FundraiserProfile {...profileInfo} />
-          <FunderBoard profileLink={props.location.href} {...profileInfo} donations={donations} />
+          <FunderBoard
+            profileLink={props.location.href}
+            {...profileInfo}
+            donations={donations}
+            onDonateClick={onDonateClick}
+          />
         </Box>
       </Box>
 
       <FundraiserOverview {...profileInfo} />
 
       <Box mt="-5vw" className="relative z-2" height="1000px">
-        <Box p={'10vw'}>
-          <FundraiserForm />
+        <Box p={'10vw'} ref={donateRef}>
+          <FundraiserDonation fundraiser={fundraiser} />
         </Box>
       </Box>
     </Layout>

--- a/gatsby-site/src/utils/api.js
+++ b/gatsby-site/src/utils/api.js
@@ -19,3 +19,11 @@ export async function getBudgets() {
 export async function getData(endpoint, headers) {
   return fetch(endpoint, { headers }).then(res => res.json());
 }
+
+export async function getFundraiserDonations(fundraiser) {
+  const { endpoint, headers } = getEndpointAndHeaders();
+  const route = `${endpoint}/api/fundraisers/${fundraiser}/donations/quarter`;
+  const result = await getData(route, headers);
+  console.log('fundraiser donations result', result);
+  return result;
+}

--- a/gatsby-site/src/utils/donate.ts
+++ b/gatsby-site/src/utils/donate.ts
@@ -211,7 +211,8 @@ export async function postDonation(donationData: IAPIDonation) {
 export function formatDonation(
   txInfo: IDonationTx,
   ipfsMetadata: IMetadata,
-  userInfo
+  userInfo,
+  extraData,
 ): IAPIDonation {
   const pledgeMonthlyUSD = parseInt(toUSDCents(ipfsMetadata.pledgeMonthlyUSD.toString()));
   const { tokens } = txInfo;
@@ -222,6 +223,7 @@ export function formatDonation(
   const donationData = {
     ...txInfo,
     ...userInfo,
+    ...extraData,
     tokens: tokens.toString(),
     metadataVersion: version,
     memo,

--- a/gatsby-site/src/utils/format.js
+++ b/gatsby-site/src/utils/format.js
@@ -66,6 +66,8 @@ export function formatDates(epochDates) {
 }
 
 export function toUSDCents(dollars) {
+  if (dollars == null) return dollars;
+
   if (dollars.includes('.')) {
     throw new Error('Dollar value must be an integer');
   }


### PR DESCRIPTION
Allow the user to make a donation from a fundraiser page, and save the donation data in the API. Render the current donations for a fundraiser on their page.

- Add fundraiser and message fields to donations table and include in donation flow
- Add endpoint to get donation stats for a given fundraiser
- Render the donor list and totals for a fundraiser on their page